### PR TITLE
Add support for derived AEAD wrappers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.5-0.20191122173911-80fcc7907c78
 	github.com/hashicorp/vault/sdk v0.1.14-0.20191229212425-c478d00be0d6
 	github.com/oracle/oci-go-sdk v12.5.0+incompatible
+	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
 	google.golang.org/api v0.14.0
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64

--- a/wrappers/aead/aead_test.go
+++ b/wrappers/aead/aead_test.go
@@ -1,6 +1,7 @@
 package aead
 
 import (
+	"crypto/rand"
 	"testing"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping"
@@ -14,5 +15,91 @@ func TestShamirVsAEAD(t *testing.T) {
 	s := NewShamirWrapper(nil)
 	if s.Type() != wrapping.Shamir {
 		t.Fatal(s.Type())
+	}
+}
+
+func TestWrapperAndDerivedWrapper(t *testing.T) {
+	rootKey := make([]byte, 32)
+	n, err := rand.Read(rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 32 {
+		t.Fatal(n)
+	}
+	root := NewWrapper(nil)
+	if err := root.SetAESGCMKeyBytes(rootKey); err != nil {
+		t.Fatal(err)
+	}
+	encBlob, err := root.Encrypt(nil, []byte("foobar"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity check
+	decVal, err := root.Decrypt(nil, encBlob, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(decVal) != "foobar" {
+		t.Fatal("mismatch in root")
+	}
+
+	sub, err := root.NewDerivedWrapper(&DerivedWrapperOptions{
+		Salt: []byte("zip"),
+		Info: []byte("zap"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This should fail as it should be a different key
+	decVal, err = sub.Decrypt(nil, encBlob, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	subEncBlob, err := sub.Encrypt(nil, []byte("foobar"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sanity check
+	subDecVal, err := sub.Decrypt(nil, subEncBlob, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(subDecVal) != "foobar" {
+		t.Fatal("mismatch in sub")
+	}
+	// This should fail too
+	decVal, err = root.Decrypt(nil, subEncBlob, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// Ensure that deriving a second subkey with the same params works
+	sub2, err := root.NewDerivedWrapper(&DerivedWrapperOptions{
+		Salt: []byte("zip"),
+		Info: []byte("zap"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subDecVal, err = sub2.Decrypt(nil, subEncBlob, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(subDecVal) != "foobar" {
+		t.Fatal("mismatch in sub2")
+	}
+
+	// Ensure that a subkey with different params doesn't work
+	subBad, err := root.NewDerivedWrapper(&DerivedWrapperOptions{
+		Salt: []byte("zap"),
+		Info: []byte("zip"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	subDecVal, err = subBad.Decrypt(nil, subEncBlob, nil)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
 }


### PR DESCRIPTION
This allows an existing AEAD wrapper to be used as the basis for a
derivation of a new wrapper with the key an HKDF-based derivation of the
original wrapper's key.

Eventually this also need not be the same key type, although we still
only support AES-GCM at the moment.