### PR TITLE
Adds a new interface that includes methods for lifecycle management of keys in a KMS

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD
 github.com/armon/go-metrics v0.3.3/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.25.37 h1:gBtB/F3dophWpsUQKN/Kni+JzYEH2mGHF4hWNtfED1w=
 github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -123,6 +124,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/frankban/quicktest v1.10.0 h1:Gfh+GAJZOAoKZsIZeZbdn2JF10kN1XHNvjsvQK8gVkE=
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
@@ -217,6 +219,7 @@ github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQ
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-immutable-radix v1.1.0 h1:vN9wG1D6KG6YHRTWr8512cxGOVgTMEfgEdSj/hr8MPc=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
@@ -241,10 +244,12 @@ github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2I
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -256,6 +261,7 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267 h1:e1ok06zG
 github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/vault/sdk v0.1.14-0.20200916184745-5576096032f8 h1:oin8pbTJ+5OTk9JLzcCF1To0A/5Xsq5xJXQYhBTaOS8=
 github.com/hashicorp/vault/sdk v0.1.14-0.20200916184745-5576096032f8/go.mod h1:7GBJyKruotYxJlye8yHyGICV7kN7dQCNsCMTrb+v5J0=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4 h1:/+f4LG96YdYE6/Duf7iZxPMRQHYaokb/CkuvkG+VPpY=
@@ -303,6 +309,7 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -314,6 +321,7 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/wrapper.go
+++ b/wrapper.go
@@ -42,9 +42,12 @@ const (
 type Purpose string
 
 const (
-	EncryptDecrypt Purpose = "encrypt_decrypt"
-	SignVerify     Purpose = "sign_verify"
-	WrapUnwrap     Purpose = "wrap_unwrap"
+	Encrypt Purpose = "encrypt"
+	Decrypt Purpose = "decrypt"
+	Sign    Purpose = "sign"
+	Verify  Purpose = "verify"
+	Wrap    Purpose = "wrap"
+	Unwrap  Purpose = "unwrap"
 )
 
 // ProtectionLevel defines where cryptographic operations are performed with a key.
@@ -58,7 +61,7 @@ const (
 // KMSKey represents a cryptographic key that can be imported into a KMS.
 type KMSKey struct {
 	Type            KeyType
-	Purpose         Purpose
+	Purposes        []Purpose
 	ProtectionLevel ProtectionLevel
 	Material        KeyMaterial
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/helper/keysutil"
 )
 
 // These values define known types of Wrappers
@@ -28,6 +29,23 @@ const (
 	HSMAutoDeprecated = "hsm-auto"
 )
 
+// Purpose defines the cryptographic capabilities of a key.
+type Purpose string
+
+const (
+	EncryptDecrypt Purpose = "encrypt_decrypt"
+	SignVerify     Purpose = "sign_verify"
+	WrapUnwrap     Purpose = "wrap_unwrap"
+)
+
+// ProtectionLevel defines where cryptographic operations are performed with a key.
+type ProtectionLevel string
+
+const (
+	Software ProtectionLevel = "software"
+	HSM      ProtectionLevel = "hsm"
+)
+
 // Wrapper is the embedded implementation of autoSeal that contains logic
 // specific to encrypting and decrypting data, or in this case keys.
 type Wrapper interface {
@@ -50,7 +68,36 @@ type Wrapper interface {
 	Decrypt(context.Context, *EncryptedBlobInfo, []byte) ([]byte, error)
 }
 
+// LifecycleWrapper is a Wrapper that implements lifecycle management for keys in a KMS.
+type LifecycleWrapper interface {
+	Wrapper
+
+	// ImportKey creates a named key by importing key material in the given KeyEntry.
+	// The key will have the given KeyType, Purpose, and ProtectionLevel if supported by the implementation.
+	// Returns the ID of a new key version and an error.
+	ImportKey(ctx context.Context, name string, kt keysutil.KeyType, ke keysutil.KeyEntry, pr Purpose, pl ProtectionLevel) (string, error)
+
+	// RotateKey rotates the named key by creating a new key version with key material in the given KeyEntry.
+	// The key version will have the given KeyType, Purpose, and ProtectionLevel if supported by the implementation.
+	// Returns the ID of a new key version and an error.
+	RotateKey(ctx context.Context, name string, kt keysutil.KeyType, ke keysutil.KeyEntry, pr Purpose, pl ProtectionLevel) (string, error)
+
+	// DeleteKey deletes the named key.
+	// Returns a bool representing if the key exists and an error.
+	DeleteKey(ctx context.Context, name string) (bool, error)
+
+	// EnableKeyVersion enables the version of the named key.
+	EnableKeyVersion(ctx context.Context, name, version string) error
+
+	// DisableKeyVersion disables the version of the named key.
+	DisableKeyVersion(ctx context.Context, name, version string) error
+}
+
 // WrapperOptions contains options used when creating a Wrapper
 type WrapperOptions struct {
 	Logger hclog.Logger
+
+	// KeyNotRequired indicates if an existing key must be
+	// supplied in the configuration for a Wrapper.
+	KeyNotRequired bool
 }

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping"
-	"github.com/hashicorp/vault/sdk/helper/keysutil"
 )
 
 const (
@@ -262,11 +261,11 @@ func (v *Wrapper) Decrypt(ctx context.Context, in *wrapping.EncryptedBlobInfo, a
 	return wrapping.NewEnvelope(nil).Decrypt(envInfo, aad)
 }
 
-func (v *Wrapper) ImportKey(_ context.Context, _ string, _ keysutil.KeyType, _ keysutil.KeyEntry, _ wrapping.Purpose, _ wrapping.ProtectionLevel) (string, error) {
+func (v *Wrapper) ImportKey(_ context.Context, _ string, _ wrapping.KMSKey) (string, error) {
 	return "", nil
 }
 
-func (v *Wrapper) RotateKey(_ context.Context, _ string, _ keysutil.KeyType, _ keysutil.KeyEntry, _ wrapping.Purpose, _ wrapping.ProtectionLevel) (string, error) {
+func (v *Wrapper) RotateKey(_ context.Context, _ string, _ wrapping.KMSKey) (string, error) {
 	return "", nil
 }
 

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -123,14 +123,14 @@ func (v *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 	}
 
 	switch {
-	case v.keyNotRequired:
-		// key not required to set config
 	case os.Getenv(EnvAzureKeyVaultWrapperKeyName) != "":
 		v.keyName = os.Getenv(EnvAzureKeyVaultWrapperKeyName)
 	case os.Getenv(EnvVaultAzureKeyVaultKeyName) != "":
 		v.keyName = os.Getenv(EnvVaultAzureKeyVaultKeyName)
 	case config["key_name"] != "":
 		v.keyName = config["key_name"]
+	case v.keyNotRequired:
+		// key not required to set config
 	default:
 		return nil, errors.New("key name is required")
 	}


### PR DESCRIPTION
## Overview

This PR adds a new interface, `LifecycleWrapper`, which is a `Wrapper` that includes interface methods for lifecycle management of keys in a KMS.

A `KeyNotRequired` field has also been added to `WrapperOptions` in order to provide consumers the option to not provide an existing key when configuring a `Wrapper`. This option is useful for those who want to use `LifecycleWrapper` methods without the need of providing an existing key for cryptographic operations. `KeyNotRequired` has a default of false in order to ensure that key validation behavior continues for existing consumers of the library.

## Testing

I tested this change manually by taking the following steps:

1. Bringing this branch into Vault via `go get`
2. Successfully compiling Vault
3. Configuring an `azurekeyvault` seal
4. Successfully auto-unsealing Vault with the `azurekeyvault` seal

Output from manual testing of this change is below:
```sh
$ git branch --show-current
master

$ go get github.com/hashicorp/go-kms-wrapping@key-lifecycle-wrapper

$ make dev
==> Checking that build is using go version >= 1.14.7...
==> Using go version 1.14.7...
==> Removing old directory...
==> Building...
Number of parallel builds: 15

-->    darwin/amd64: github.com/hashicorp/vault

==> Results:
total 258264
-rwxr-xr-x  1 austingebauer  staff   126M Sep 21 15:42 vault

$ cat config/ha1.hcl 
storage "consul" {}
listener "tcp" {
  address = "127.0.0.1:8200"
  tls_disable = true
}

seal "azurekeyvault" {
  tenant_id      = "<redacted>"
  client_id      = "<redacted>"
  client_secret  = "<redacted>"
  vault_name     = "keyvault-keys-test"
  key_name       = "unseal"
}

$ vault server -log-level=trace -config config/ha1.hcl > /tmp/s1.log 2>&1 &
[1] 11740

$ vault operator init -recovery-shares 1 -recovery-threshold 1 
Recovery Key 1: 1MCS4S6SS4IAdxFocvqbcVgzYaXIWBoHn1jk+k2LlYI=

Initial Root Token: s.H1aNRwOTC0Qwb5TXFyJYLcpS

Success! Vault is initialized

Recovery key initialized with 1 key shares and a key threshold of 1. Please
securely distribute the key shares printed above.

$ vault status
Key                      Value
---                      -----
Recovery Seal Type       shamir
Initialized              true
Sealed                   false
Total Recovery Shares    1
Threshold                1
Version                  1.5.0
Storage Type             consul
Cluster Name             vault-cluster-23b8e140
Cluster ID               336573dd-492d-db31-04f8-9843cb02e028
HA Enabled               true
HA Cluster               https://127.0.0.1:8201
HA Mode                  active
```