### PR TITLE
Adds Azure Key Vault implementation of LifecycleWrapper methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/Azure/azure-sdk-for-go v36.2.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.10.1
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
+	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190620160927-9418d7b0cd0f
 	github.com/aws/aws-sdk-go v1.30.27
 	github.com/golang/protobuf v1.4.2
+	github.com/google/tink/go v1.4.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-uuid v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,7 @@ github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.25.37 h1:gBtB/F3dophWpsUQKN/Kni+JzYEH2mGHF4hWNtfED1w=
 github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.25.39/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.27 h1:9gPjZWVDSoQrBO2AvqrWObS6KAZByfEJxQoCYo4ZfK0=
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
@@ -199,6 +200,8 @@ github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/tink/go v1.4.0 h1:7Ihv6n6/0zPrm2GRAeeF408P9Y00HXC2J6tvUzgb2sg=
+github.com/google/tink/go v1.4.0/go.mod h1:OdW+ACSIXwGiPOWJiRTdoKzStsnqo8ZOsTzchWLy2DY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
@@ -428,6 +431,7 @@ golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480/go.mod h1:WFFai1msRO1wXaE
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191119213627-4f8c1d86b1ba/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=

--- a/wrapper.go
+++ b/wrapper.go
@@ -30,7 +30,7 @@ const (
 )
 
 // KeyType defines types of cryptographic keys.
-type KeyType int
+type KeyType uint32
 
 const (
 	RSA2048 KeyType = 1 + iota
@@ -39,7 +39,7 @@ const (
 )
 
 // Purpose defines the cryptographic capabilities of a key.
-type Purpose int
+type Purpose uint32
 
 const (
 	Encrypt Purpose = 1 + iota
@@ -51,7 +51,7 @@ const (
 )
 
 // ProtectionLevel defines where cryptographic operations are performed with a key.
-type ProtectionLevel int
+type ProtectionLevel uint32
 
 const (
 	Software ProtectionLevel = 1 + iota

--- a/wrapper.go
+++ b/wrapper.go
@@ -30,32 +30,32 @@ const (
 )
 
 // KeyType defines types of cryptographic keys.
-type KeyType string
+type KeyType int
 
 const (
-	RSA2048 KeyType = "rsa-2048"
-	RSA3072 KeyType = "rsa-3072"
-	RSA4096 KeyType = "rsa-4096"
+	RSA2048 KeyType = iota
+	RSA3072
+	RSA4096
 )
 
 // Purpose defines the cryptographic capabilities of a key.
-type Purpose string
+type Purpose int
 
 const (
-	Encrypt Purpose = "encrypt"
-	Decrypt Purpose = "decrypt"
-	Sign    Purpose = "sign"
-	Verify  Purpose = "verify"
-	Wrap    Purpose = "wrap"
-	Unwrap  Purpose = "unwrap"
+	Encrypt Purpose = iota
+	Decrypt
+	Sign
+	Verify
+	Wrap
+	Unwrap
 )
 
 // ProtectionLevel defines where cryptographic operations are performed with a key.
-type ProtectionLevel string
+type ProtectionLevel int
 
 const (
-	Software ProtectionLevel = "software"
-	HSM      ProtectionLevel = "hsm"
+	Software ProtectionLevel = iota
+	HSM
 )
 
 // KMSKey represents a cryptographic key that can be imported into a KMS.
@@ -125,4 +125,47 @@ type WrapperOptions struct {
 	// KeyNotRequired indicates if an existing key must be
 	// supplied in the configuration for a Wrapper.
 	KeyNotRequired bool
+}
+
+func (k KeyType) String() string {
+	switch k {
+	case RSA2048:
+		return "rsa-2048"
+	case RSA3072:
+		return "rsa-3072"
+	case RSA4096:
+		return "rsa-4096"
+	default:
+		return "unknown"
+	}
+}
+
+func (p Purpose) String() string {
+	switch p {
+	case Encrypt:
+		return "encrypt"
+	case Decrypt:
+		return "decrypt"
+	case Sign:
+		return "sign"
+	case Verify:
+		return "verify"
+	case Wrap:
+		return "wrap"
+	case Unwrap:
+		return "unwrap"
+	default:
+		return "unknown"
+	}
+}
+
+func (p ProtectionLevel) String() string {
+	switch p {
+	case Software:
+		return "software"
+	case HSM:
+		return "hsm"
+	default:
+		return "unknown"
+	}
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -33,7 +33,7 @@ const (
 type KeyType int
 
 const (
-	RSA2048 KeyType = iota
+	RSA2048 KeyType = 1 + iota
 	RSA3072
 	RSA4096
 )
@@ -42,7 +42,7 @@ const (
 type Purpose int
 
 const (
-	Encrypt Purpose = iota
+	Encrypt Purpose = 1 + iota
 	Decrypt
 	Sign
 	Verify
@@ -54,7 +54,7 @@ const (
 type ProtectionLevel int
 
 const (
-	Software ProtectionLevel = iota
+	Software ProtectionLevel = 1 + iota
 	HSM
 )
 

--- a/wrapper.go
+++ b/wrapper.go
@@ -33,9 +33,9 @@ const (
 type KeyType string
 
 const (
-	RSA2048 KeyType = "rsa_2048"
-	RSA3072 KeyType = "rsa_3072"
-	RSA4096 KeyType = "rsa_4096"
+	RSA2048 KeyType = "rsa-2048"
+	RSA3072 KeyType = "rsa-3072"
+	RSA4096 KeyType = "rsa-4096"
 )
 
 // Purpose defines the cryptographic capabilities of a key.

--- a/wrapper.go
+++ b/wrapper.go
@@ -108,7 +108,7 @@ type LifecycleWrapper interface {
 	RotateKey(ctx context.Context, name string, key KMSKey) (string, error)
 
 	// DeleteKey deletes the named key.
-	// Returns a bool representing if the key exists and an error.
+	// Returns a bool representing if the key existed before deletion and an error.
 	DeleteKey(ctx context.Context, name string) (bool, error)
 
 	// EnableKeyVersion enables the version of the named key.

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -370,6 +370,10 @@ func (v *Wrapper) ImportKey(ctx context.Context, name string, key wrapping.KMSKe
 	return parseKeyVersion(to.String(imported.Key.Kid)), nil
 }
 
+// RotateKey rotates the key with the given name in Azure Key Vault. Rotating a
+// key is achieved by importing the material in the given KMSKey into an existing
+// key. After rotation, the current (latest) version of the key will contain the
+// material in the given KMSKey.
 func (v *Wrapper) RotateKey(ctx context.Context, name string, key wrapping.KMSKey) (string, error) {
 	// Check that the key exists before importing a new version
 	if _, err := v.client.GetKey(ctx, v.baseURL, name, ""); err != nil {
@@ -380,11 +384,15 @@ func (v *Wrapper) RotateKey(ctx context.Context, name string, key wrapping.KMSKe
 	return v.ImportKey(ctx, name, key)
 }
 
+// DeleteKey deletes the key with the given name from Azure Key Vault. Deleting a key
+// will result in the deletion of all versions of the key. After deletion, the key
+// cannot be used for crypto operations.
 func (v *Wrapper) DeleteKey(ctx context.Context, name string) (bool, error) {
 	res, err := v.client.DeleteKey(ctx, v.baseURL, name)
 	return res.StatusCode != http.StatusNotFound, err
 }
 
+// EnableKeyVersion enables the given version of the given key.
 func (v *Wrapper) EnableKeyVersion(ctx context.Context, name, version string) error {
 	_, err := v.client.UpdateKey(ctx, v.baseURL, name, version, keyvault.KeyUpdateParameters{
 		KeyAttributes: &keyvault.KeyAttributes{
@@ -394,6 +402,7 @@ func (v *Wrapper) EnableKeyVersion(ctx context.Context, name, version string) er
 	return err
 }
 
+// DisableKeyVersion disables the given version of the given key.
 func (v *Wrapper) DisableKeyVersion(ctx context.Context, name, version string) error {
 	_, err := v.client.UpdateKey(ctx, v.baseURL, name, version, keyvault.KeyUpdateParameters{
 		KeyAttributes: &keyvault.KeyAttributes{

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -505,7 +505,10 @@ func (v *Wrapper) wrapTargetKey(pub *rsa.PublicKey, targetKey []byte) (string, e
 		return "", err
 	}
 
-	// Zero the ephemeral AES key
+	// Zero the memory of the ephemeral AES key. This is a best-effort
+	// cleanup, as the buffer may have been copied during a garbage
+	// collection. Exposure of the key in memory is minimized by
+	// zeroing the buffer as soon as it's no longer needed.
 	for i := range aesKey {
 		aesKey[i] = 0
 	}

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -324,6 +324,8 @@ func (v *Wrapper) ImportKey(ctx context.Context, name string, key wrapping.KMSKe
 		if targetKey, err = x509.MarshalPKCS8PrivateKey(key.Material.RSAKey); err != nil {
 			return "", err
 		}
+	default:
+		return "", fmt.Errorf("%q does not support key type %q", v.Type(), key.Type)
 	}
 
 	// Produce the wrapped key material needed for import

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -301,7 +301,9 @@ func (v *Wrapper) ImportKey(ctx context.Context, name string, key wrapping.KMSKe
 		return "", fmt.Errorf("error generating KEK: %w", err)
 	}
 	defer func() {
-		v.client.DeleteKey(ctx, v.buildBaseURL(), kekName)
+		if _, err := v.client.DeleteKey(ctx, v.buildBaseURL(), kekName); err != nil {
+			v.logger.Warn("error deleting KEK", "name", kekName, "error", err)
+		}
 	}()
 
 	// Parse the RSA public key of the KEK

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -2,20 +2,31 @@ package azurekeyvault
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"net/http"
 	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/google/tink/go/kwp/subtle"
 	"github.com/hashicorp/go-hclog"
 	wrapping "github.com/hashicorp/go-kms-wrapping"
+	"github.com/hashicorp/go-uuid"
 )
 
 const (
@@ -261,24 +272,293 @@ func (v *Wrapper) Decrypt(ctx context.Context, in *wrapping.EncryptedBlobInfo, a
 	return wrapping.NewEnvelope(nil).Decrypt(envInfo, aad)
 }
 
-func (v *Wrapper) ImportKey(_ context.Context, _ string, _ wrapping.KMSKey) (string, error) {
-	return "", nil
+// ImportKey imports the given key into Azure Key Vault by implementing the
+// Azure Key Vault bring your own key (BYOK) specification. The BYOK specification is
+// detailed at https://docs.microsoft.com/en-us/azure/key-vault/keys/byok-specification.
+func (v *Wrapper) ImportKey(ctx context.Context, name string, key wrapping.KMSKey) (string, error) {
+	if err := v.validateKMSKey(key); err != nil {
+		return "", err
+	}
+
+	// Generate a UUID for the name of the Key Exchange Key (KEK)
+	kekName, err := uuid.GenerateUUID()
+	if err != nil {
+		return "", err
+	}
+
+	// Generate an HSM backed RSA key pair in Azure Key Vault.
+	// This key will be used as the KEK and has an expiration.
+	exp := date.UnixTime(time.Now().Add(3 * time.Minute))
+	kekBundle, err := v.client.CreateKey(ctx, v.buildBaseURL(), kekName, keyvault.KeyCreateParameters{
+		Kty:     keyvault.RSAHSM,
+		KeySize: to.Int32Ptr(2048),
+		KeyOps:  &[]keyvault.JSONWebKeyOperation{"import"},
+		KeyAttributes: &keyvault.KeyAttributes{
+			Expires: &exp,
+		},
+	})
+	if err != nil || kekBundle.Key == nil {
+		return "", fmt.Errorf("error generating KEK: %w", err)
+	}
+	defer func() {
+		v.client.DeleteKey(ctx, v.buildBaseURL(), kekName)
+	}()
+
+	// Parse the RSA public key of the KEK
+	kekPubKey, err := jwkToRSAPublicKey(kekBundle.Key)
+	if err != nil {
+		return "", err
+	}
+
+	// Produce the target key plaintext
+	var targetKey []byte
+	switch key.Type {
+	case wrapping.RSA2048, wrapping.RSA3072, wrapping.RSA4096:
+		// For an RSA key, the private key ASN.1 DER encoding [RFC3447] wrapped in PKCS#8 [RFC5208]
+		if targetKey, err = x509.MarshalPKCS8PrivateKey(key.Material.RSAKey); err != nil {
+			return "", err
+		}
+	}
+
+	// Produce the wrapped key material needed for import
+	wrappedKeyMaterial, err := v.wrapTargetKey(kekPubKey, targetKey)
+	if err != nil {
+		return "", err
+	}
+
+	// Create the key transfer blob
+	b := keyTransferBlob{
+		SchemaVersion: "1.0.0",
+		Header: keyTransferBlobHeader{
+			Alg: "dir",
+			Enc: "CKM_RSA_AES_KEY_WRAP",
+			Kid: to.String(kekBundle.Key.Kid),
+		},
+		CipherText: wrappedKeyMaterial,
+		Generator:  "Hashicorp",
+	}
+	ktb, err := json.Marshal(b)
+	if err != nil {
+		return "", err
+	}
+	ktbEncoded := base64.RawURLEncoding.EncodeToString(ktb)
+
+	// Upload the key transfer blob to import the key
+	kty := v.keyTypeToKty(key.Type)
+	ops := v.keyPurposesToKeyOps(key.Purposes)
+	imported, err := v.client.ImportKey(ctx, v.buildBaseURL(), name, keyvault.KeyImportParameters{
+		Key: &keyvault.JSONWebKey{
+			Kty:    kty,
+			T:      to.StringPtr(ktbEncoded),
+			KeyOps: to.StringSlicePtr(ops),
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("error importing key: %w", err)
+	}
+	if imported.Key == nil || imported.Key.Kid == nil {
+		return "", errors.New("imported key is missing identifier")
+	}
+
+	// Return the version ID generated for the imported key
+	return parseKeyVersion(to.String(imported.Key.Kid)), nil
 }
 
-func (v *Wrapper) RotateKey(_ context.Context, _ string, _ wrapping.KMSKey) (string, error) {
-	return "", nil
+func (v *Wrapper) RotateKey(ctx context.Context, name string, key wrapping.KMSKey) (string, error) {
+	// Check that the key exists before importing a new version
+	if _, err := v.client.GetKey(ctx, v.buildBaseURL(), name, ""); err != nil {
+		return "", err
+	}
+
+	// Rotation works by importing key material into an existing key
+	return v.ImportKey(ctx, name, key)
 }
 
-func (v *Wrapper) DeleteKey(_ context.Context, _ string) (bool, error) {
-	return false, nil
+func (v *Wrapper) DeleteKey(ctx context.Context, name string) (bool, error) {
+	res, err := v.client.DeleteKey(ctx, v.buildBaseURL(), name)
+	return res.StatusCode != http.StatusNotFound, err
 }
 
-func (v *Wrapper) EnableKeyVersion(_ context.Context, _, _ string) error {
+func (v *Wrapper) EnableKeyVersion(ctx context.Context, name, version string) error {
+	_, err := v.client.UpdateKey(ctx, v.buildBaseURL(), name, version, keyvault.KeyUpdateParameters{
+		KeyAttributes: &keyvault.KeyAttributes{
+			Enabled: to.BoolPtr(true),
+		},
+	})
+	return err
+}
+
+func (v *Wrapper) DisableKeyVersion(ctx context.Context, name, version string) error {
+	_, err := v.client.UpdateKey(ctx, v.buildBaseURL(), name, version, keyvault.KeyUpdateParameters{
+		KeyAttributes: &keyvault.KeyAttributes{
+			Enabled: to.BoolPtr(false),
+		},
+	})
+	return err
+}
+
+// keyTransferBlob represents the structure of a key transfer blob
+// used to import a key into Azure Key Vault. The format of the key
+// transfer blob uses JSON Web Encryption compact serialization [RFC7516]
+// primarily as a vehicle for delivering the required metadata to the
+// service for correct decryption.
+type keyTransferBlob struct {
+	SchemaVersion string                `json:"schema_version"`
+	Header        keyTransferBlobHeader `json:"header"`
+	CipherText    string                `json:"ciphertext"`
+	Generator     string                `json:"generator"`
+}
+
+// keyTransferBlobHeader represents the header of a key transfer blob.
+type keyTransferBlobHeader struct {
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	Enc string `json:"enc"`
+}
+
+// jwkToRSAPublicKey returns a pointer to an rsa.PublicKey that contains
+// the modulus and public exponent from the given keyvault.JSONWebKey (JWK).
+// Both the RSA modulus "N" and public exponent "E" in the JWK are
+// parsed as the base64url encoding of the value's unsigned big-endian
+// representation as an octet sequence. For more details, see
+// https://tools.ietf.org/html/rfc7518#section-6.3.1
+func jwkToRSAPublicKey(jwk *keyvault.JSONWebKey) (*rsa.PublicKey, error) {
+	if jwk == nil || jwk.N == nil || jwk.E == nil {
+		return nil, fmt.Errorf("must provide an RSA type JSONWebKey")
+	}
+
+	// Decode the RSA modulus
+	base64N := to.String(jwk.N)
+	nd, err := base64.RawURLEncoding.DecodeString(base64N)
+	if err != nil {
+		return nil, err
+	}
+	n := new(big.Int).SetBytes(nd)
+
+	// Decode the RSA public exponent
+	base64E := to.String(jwk.E)
+	ed, err := base64.RawURLEncoding.DecodeString(base64E)
+	if err != nil {
+		return nil, err
+	}
+	e := new(big.Int).SetBytes(ed)
+
+	return &rsa.PublicKey{
+		N: n,
+		E: int(e.Uint64()),
+	}, nil
+}
+
+// wrapTargetKey returns wrapped key material according to the steps outlined in
+// the Azure Key Vault BYOK specification. For details, see the specification at
+// https://docs.microsoft.com/en-us/azure/key-vault/keys/byok-specification#key-transfer-blob.
+//
+// More specific details related to the wrapping and unwrapping mechanism used can be found at
+// http://docs.oasis-open.org/pkcs11/pkcs11-curr/v2.40/cos01/pkcs11-curr-v2.40-cos01.html#_Toc408226908.
+func (v *Wrapper) wrapTargetKey(pub *rsa.PublicKey, targetKey []byte) (string, error) {
+	// Generate an ephemeral AES key
+	aesKey, err := uuid.GenerateRandomBytes(32)
+	if err != nil {
+		return "", err
+	}
+
+	// Wrap the AES key with the RSA public key using RSA-OAEP with SHA1
+	aesKeyWrapped, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, pub, aesKey, []byte{})
+	if err != nil {
+		return "", err
+	}
+
+	// Wrap the target key plaintext using AES Key Wrap with Padding [RFC5649]
+	kwp, err := subtle.NewKWP(aesKey)
+	if err != nil {
+		return "", err
+	}
+	wrappedTargetKey, err := kwp.Wrap(targetKey)
+	if err != nil {
+		return "", err
+	}
+
+	// Zero the ephemeral AES key
+	for i := range aesKey {
+		aesKey[i] = 0
+	}
+
+	// Concatenate the wrapped AES key and the wrapped target
+	// key to produce the final ciphertext
+	wrappedKeyMaterial := append(aesKeyWrapped, wrappedTargetKey...)
+
+	// Return a base64 URL encoding of the ciphertext
+	return base64.RawURLEncoding.EncodeToString(wrappedKeyMaterial), nil
+}
+
+// validateKMSKey validates the given KSMKey with respect to the limitations of Azure Key Vault.
+func (v *Wrapper) validateKMSKey(key wrapping.KMSKey) error {
+	// Validate the key type and material
+	switch key.Type {
+	case wrapping.RSA2048, wrapping.RSA3072, wrapping.RSA4096:
+		if key.Material.RSAKey == nil {
+			return fmt.Errorf("must provide RSA key for key type %q", key.Type)
+		}
+	default:
+		return fmt.Errorf("%q does not support key type %q", v.Type(), key.Type)
+	}
+
+	// Validate the key purpose
+	if len(key.Purposes) == 0 {
+		return errors.New("key must have at least one purpose")
+	}
+	for _, p := range key.Purposes {
+		switch p {
+		case wrapping.Encrypt, wrapping.Decrypt, wrapping.Sign,
+			wrapping.Verify, wrapping.Wrap, wrapping.Unwrap:
+		default:
+			return fmt.Errorf("%q does not support key purpose %q", v.Type(), p)
+		}
+	}
+
+	// Validate the key protection level
+	switch key.ProtectionLevel {
+	case wrapping.HSM:
+	default:
+		return fmt.Errorf("%q does not support key protection level %q", v.Type(), key.ProtectionLevel)
+	}
+
 	return nil
 }
 
-func (v *Wrapper) DisableKeyVersion(_ context.Context, _, _ string) error {
-	return nil
+// keyPurposesToKeyOps translates a slice of wrapping.Purpose values
+// into a slice of JSON Web Key (JWK) [RFC7517] key_ops. For details,
+// see https://tools.ietf.org/html/rfc7517#section-4.3.
+func (v *Wrapper) keyPurposesToKeyOps(purposes []wrapping.Purpose) []string {
+	ops := make([]string, 0)
+	for _, p := range purposes {
+		switch p {
+		case wrapping.Encrypt:
+			ops = append(ops, "encrypt")
+		case wrapping.Decrypt:
+			ops = append(ops, "decrypt")
+		case wrapping.Sign:
+			ops = append(ops, "sign")
+		case wrapping.Verify:
+			ops = append(ops, "verify")
+		case wrapping.Wrap:
+			ops = append(ops, "wrapKey")
+		case wrapping.Unwrap:
+			ops = append(ops, "unwrapKey")
+		}
+	}
+	return ops
+}
+
+// keyTypeToKty translates the given wrapping.KeyType to a its equivalent keyvault.JSONWebKeyType.
+func (v *Wrapper) keyTypeToKty(kt wrapping.KeyType) keyvault.JSONWebKeyType {
+	switch kt {
+	case wrapping.RSA2048, wrapping.RSA3072, wrapping.RSA4096:
+		// Keys can only be imported with HSM protection,
+		// so HSM variants of the key type are returned.
+		return keyvault.RSAHSM
+	}
+	return ""
 }
 
 func (v *Wrapper) buildBaseURL() string {

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -341,7 +341,7 @@ func (v *Wrapper) ImportKey(ctx context.Context, name string, key wrapping.KMSKe
 			Kid: to.String(kekBundle.Key.Kid),
 		},
 		CipherText: wrappedKeyMaterial,
-		Generator:  "Hashicorp",
+		Generator:  "HashiCorp",
 	}
 	ktb, err := json.Marshal(b)
 	if err != nil {

--- a/wrappers/azurekeyvault/azurekeyvault_acc_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_acc_test.go
@@ -174,8 +174,11 @@ func TestAzureKeyVault_KeyLifecycle(t *testing.T) {
 
 	// Delete the key
 	exists, err := s.DeleteKey(ctx, name)
-	if err != nil || !exists {
+	if err != nil {
 		t.Fatalf("err: %s", err.Error())
+	}
+	if !exists {
+		t.Fatal("expected key to exist before deletion")
 	}
 
 	// Expect that the key no longer exists

--- a/wrappers/azurekeyvault/azurekeyvault_acc_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_acc_test.go
@@ -2,9 +2,18 @@ package azurekeyvault
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/Azure/go-autorest/autorest/to"
+	wrapping "github.com/hashicorp/go-kms-wrapping"
 )
 
 func TestAzureKeyVault_SetConfig(t *testing.T) {
@@ -55,5 +64,149 @@ func TestAzureKeyVault_Lifecycle(t *testing.T) {
 
 	if !reflect.DeepEqual(input, pt) {
 		t.Fatalf("expected %s, got %s", input, pt)
+	}
+}
+
+// TestAzureKeyVault_KeyLifecycle tests implementations of the
+// wrapping.LifecycleWrapper interface methods for Azure Key Vault.
+func TestAzureKeyVault_KeyLifecycle(t *testing.T) {
+	if os.Getenv("VAULT_ACC") == "" {
+		t.SkipNow()
+	}
+	ctx := context.Background()
+
+	// Configure the wrapper
+	opts := &wrapping.WrapperOptions{KeyNotRequired: true}
+	s := NewWrapper(opts)
+	_, err := s.SetConfig(nil)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+
+	// Generate an RSA key to import
+	rsa1 := testGenerateRSAKey(t)
+
+	// Create a KMSKey containing the RSA key
+	kmsKey := wrapping.KMSKey{
+		Type:            wrapping.RSA2048,
+		ProtectionLevel: wrapping.HSM,
+		Purposes: []wrapping.Purpose{
+			wrapping.Encrypt,
+			wrapping.Decrypt,
+		},
+		Material: wrapping.KeyMaterial{
+			RSAKey: rsa1,
+		},
+	}
+
+	// Import the key
+	name := fmt.Sprintf("test-%d", time.Now().Unix())
+	version1, err := s.ImportKey(ctx, name, kmsKey)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	if version1 == "" {
+		t.Fatal("expected non-empty version")
+	}
+	t.Cleanup(func() {
+		if exists, err := s.DeleteKey(ctx, name); exists && err != nil {
+			t.Fatalf("failed to clean up key %q", name)
+		}
+	})
+
+	// Get the public key for version 1 from Azure key vault and assert
+	// it matches the public key that was generated and imported.
+	kb, err := s.client.GetKey(ctx, s.buildBaseURL(), name, version1)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	testAssertPublicKeysMatch(t, kb.Key, rsa1.PublicKey)
+
+	// Generate an additional RSA key to use for rotation.
+	// We can reuse the KMSKey by swapping in the new material.
+	rsa2 := testGenerateRSAKey(t)
+	kmsKey.Material.RSAKey = rsa2
+
+	// Rotate the key
+	version2, err := s.RotateKey(ctx, name, kmsKey)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	if version2 == "" {
+		t.Fatal("expected non-empty version")
+	}
+
+	// Get the public key for version 2 from Azure key vault and assert
+	// it matches the public key that was provided for the rotation.
+	kb, err = s.client.GetKey(ctx, s.buildBaseURL(), name, version2)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	testAssertPublicKeysMatch(t, kb.Key, rsa2.PublicKey)
+
+	// Expect that both versions of the key can be disabled
+	for _, v := range []string{version1, version2} {
+		if err = s.DisableKeyVersion(ctx, name, v); err != nil {
+			t.Fatalf("err: %s", err.Error())
+		}
+		kb, err := s.client.GetKey(ctx, s.buildBaseURL(), name, v)
+		if err != nil {
+			t.Fatalf("err: %s", err.Error())
+		}
+		if to.Bool(kb.Attributes.Enabled) {
+			t.Fatalf("expected key version %q to be disabled", v)
+		}
+	}
+
+	// Expect that both versions of the key can be enabled
+	for _, v := range []string{version1, version2} {
+		if err = s.EnableKeyVersion(ctx, name, v); err != nil {
+			t.Fatalf("err: %s", err.Error())
+		}
+		kb, err := s.client.GetKey(ctx, s.buildBaseURL(), name, v)
+		if err != nil {
+			t.Fatalf("err: %s", err.Error())
+		}
+		if !to.Bool(kb.Attributes.Enabled) {
+			t.Fatalf("expected key version %q to be enabled", v)
+		}
+	}
+
+	// Delete the key
+	exists, err := s.DeleteKey(ctx, name)
+	if err != nil || !exists {
+		t.Fatalf("err: %s", err.Error())
+	}
+
+	// Expect that the key no longer exists
+	kb, err = s.client.GetKey(ctx, s.buildBaseURL(), name, "")
+	if err == nil || kb.StatusCode != http.StatusNotFound {
+		t.Fatal("expected key to be not found")
+	}
+}
+
+func testGenerateRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+
+	return k
+}
+
+func testAssertPublicKeysMatch(t *testing.T, jwk *keyvault.JSONWebKey, pub rsa.PublicKey) {
+	t.Helper()
+
+	azureRSAPub, err := jwkToRSAPublicKey(jwk)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	if pub.N.Cmp(azureRSAPub.N) != 0 {
+		t.Fatalf("expected same RSA modulus")
+	}
+	if pub.E != azureRSAPub.E {
+		t.Fatalf("expected same RSA public exponent")
 	}
 }

--- a/wrappers/azurekeyvault/azurekeyvault_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_test.go
@@ -198,11 +198,11 @@ func TestWrapper_validateKMSKey(t *testing.T) {
 			name: "invalid KMS key unsupported type",
 			args: args{
 				wrapping.KMSKey{
-					Type: wrapping.KeyType("aes_256"),
+					Type: wrapping.KeyType(1234),
 					Purposes: []wrapping.Purpose{
 						wrapping.Decrypt,
 					},
-					ProtectionLevel: wrapping.Software,
+					ProtectionLevel: wrapping.HSM,
 					Material: wrapping.KeyMaterial{
 						RSAKey: &rsa.PrivateKey{},
 					},
@@ -216,9 +216,25 @@ func TestWrapper_validateKMSKey(t *testing.T) {
 				wrapping.KMSKey{
 					Type: wrapping.RSA2048,
 					Purposes: []wrapping.Purpose{
-						wrapping.Purpose("invalid"),
+						wrapping.Purpose(1234),
 					},
-					ProtectionLevel: wrapping.Software,
+					ProtectionLevel: wrapping.HSM,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid KMS key unsupported protection level",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA2048,
+					Purposes: []wrapping.Purpose{
+						wrapping.Decrypt,
+					},
+					ProtectionLevel: wrapping.ProtectionLevel(1234),
 					Material: wrapping.KeyMaterial{
 						RSAKey: &rsa.PrivateKey{},
 					},
@@ -256,7 +272,7 @@ func TestWrapper_keyPurposesToKeyOps(t *testing.T) {
 		{
 			name: "unsupported purpose",
 			args: args{
-				purposes: []wrapping.Purpose{wrapping.Purpose("unsupported")},
+				purposes: []wrapping.Purpose{wrapping.Purpose(1234)},
 			},
 			want: []string{},
 		},
@@ -309,9 +325,9 @@ func TestWrapper_keyTypeToKty(t *testing.T) {
 		want keyvault.JSONWebKeyType
 	}{
 		{
-			name: "empty key type",
+			name: "unsupported key type",
 			args: args{
-				kt: wrapping.KeyType(""),
+				kt: wrapping.KeyType(1234),
 			},
 			want: keyvault.JSONWebKeyType(""),
 		},

--- a/wrappers/azurekeyvault/azurekeyvault_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_test.go
@@ -1,0 +1,348 @@
+package azurekeyvault
+
+import (
+	"crypto/rsa"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/Azure/go-autorest/autorest/to"
+	wrapping "github.com/hashicorp/go-kms-wrapping"
+)
+
+func Test_jwkToRSAPublicKey(t *testing.T) {
+	type args struct {
+		jwk *keyvault.JSONWebKey
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *rsa.PublicKey
+		wantErr bool
+	}{
+		{
+			name:    "nil JSONWebKey",
+			args:    args{},
+			wantErr: true,
+		},
+		{
+			name: "invalid JSONWebKey missing N",
+			args: args{
+				&keyvault.JSONWebKey{
+					E: to.StringPtr("AQAB"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid JSONWebKey missing E",
+			args: args{
+				&keyvault.JSONWebKey{
+					N: to.StringPtr("AQAB"),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid JSONWebKey",
+			args: args{
+				&keyvault.JSONWebKey{
+					N: to.StringPtr("AAEAAQ"),
+					E: to.StringPtr("AQAB"),
+				},
+			},
+			want: &rsa.PublicKey{
+				// "AAEAAQ" -> []byte{0,1,0,1} -> 65537
+				// "AQAB"   -> []byte{1,0,1}   -> 65537
+				// "AAEAAQ" and "AQAB" are equivalent after read big-endian
+				N: big.NewInt(65537),
+				E: 65537,
+			},
+		},
+		{
+			name: "valid JSONWebKey",
+			args: args{
+				&keyvault.JSONWebKey{
+					N: to.StringPtr("AQAB"),
+					E: to.StringPtr("AAEAAQ"),
+				},
+			},
+			want: &rsa.PublicKey{
+				// "AAEAAQ" -> []byte{0,1,0,1} -> 65537
+				// "AQAB"   -> []byte{1,0,1}   -> 65537
+				// "AAEAAQ" and "AQAB" are equivalent after read big-endian
+				N: big.NewInt(0).SetBytes([]byte{1, 0, 1}),
+				E: int(big.NewInt(0).SetBytes([]byte{1, 0, 1}).Int64()),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jwkToRSAPublicKey(tt.args.jwk)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jwkToRSAPublicKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("jwkToRSAPublicKey() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapper_validateKMSKey(t *testing.T) {
+	type args struct {
+		key wrapping.KMSKey
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid KMS key single-purpose",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA3072,
+					Purposes: []wrapping.Purpose{
+						wrapping.Sign,
+					},
+					ProtectionLevel: wrapping.HSM,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+		},
+		{
+			name: "valid KMS key multi-purpose",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA2048,
+					Purposes: []wrapping.Purpose{
+						wrapping.Encrypt,
+						wrapping.Decrypt,
+					},
+					ProtectionLevel: wrapping.HSM,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+		},
+		{
+			name: "valid KMS key multi-purpose",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA3072,
+					Purposes: []wrapping.Purpose{
+						wrapping.Sign,
+						wrapping.Verify,
+					},
+					ProtectionLevel: wrapping.HSM,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+		},
+		{
+			name: "valid KMS key multi-purpose",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA3072,
+					Purposes: []wrapping.Purpose{
+						wrapping.Unwrap,
+						wrapping.Wrap,
+					},
+					ProtectionLevel: wrapping.HSM,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid KMS key empty purpose",
+			args: args{
+				wrapping.KMSKey{
+					Type:            wrapping.RSA2048,
+					Purposes:        []wrapping.Purpose{},
+					ProtectionLevel: wrapping.HSM,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid KMS key protection level",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA2048,
+					Purposes: []wrapping.Purpose{
+						wrapping.Decrypt,
+					},
+					ProtectionLevel: wrapping.Software,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid KMS key unsupported type",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.KeyType("aes_256"),
+					Purposes: []wrapping.Purpose{
+						wrapping.Decrypt,
+					},
+					ProtectionLevel: wrapping.Software,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid KMS key unsupported purpose",
+			args: args{
+				wrapping.KMSKey{
+					Type: wrapping.RSA2048,
+					Purposes: []wrapping.Purpose{
+						wrapping.Purpose("invalid"),
+					},
+					ProtectionLevel: wrapping.Software,
+					Material: wrapping.KeyMaterial{
+						RSAKey: &rsa.PrivateKey{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Wrapper{}
+			if err := v.validateKMSKey(tt.args.key); (err != nil) != tt.wantErr {
+				t.Errorf("validateKMSKey() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWrapper_keyPurposesToKeyOps(t *testing.T) {
+	type args struct {
+		purposes []wrapping.Purpose
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "empty purpose",
+			args: args{
+				purposes: []wrapping.Purpose{},
+			},
+			want: []string{},
+		},
+		{
+			name: "unsupported purpose",
+			args: args{
+				purposes: []wrapping.Purpose{wrapping.Purpose("unsupported")},
+			},
+			want: []string{},
+		},
+		{
+			name: "single purpose",
+			args: args{
+				purposes: []wrapping.Purpose{wrapping.Encrypt},
+			},
+			want: []string{"encrypt"},
+		},
+		{
+			name: "multiple purposes",
+			args: args{
+				purposes: []wrapping.Purpose{
+					wrapping.Encrypt,
+					wrapping.Decrypt,
+					wrapping.Sign,
+					wrapping.Verify,
+					wrapping.Wrap,
+					wrapping.Unwrap,
+				},
+			},
+			want: []string{
+				"encrypt",
+				"decrypt",
+				"sign",
+				"verify",
+				"wrapKey",
+				"unwrapKey",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Wrapper{}
+			if got := v.keyPurposesToKeyOps(tt.args.purposes); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("keyPurposesToKeyOps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapper_keyTypeToKty(t *testing.T) {
+	type args struct {
+		kt wrapping.KeyType
+	}
+	tests := []struct {
+		name string
+		args args
+		want keyvault.JSONWebKeyType
+	}{
+		{
+			name: "empty key type",
+			args: args{
+				kt: wrapping.KeyType(""),
+			},
+			want: keyvault.JSONWebKeyType(""),
+		},
+		{
+			name: "RSA2048 key type",
+			args: args{
+				kt: wrapping.RSA2048,
+			},
+			want: keyvault.RSAHSM,
+		},
+		{
+			name: "RSA3072 key type",
+			args: args{
+				kt: wrapping.RSA3072,
+			},
+			want: keyvault.RSAHSM,
+		},
+		{
+			name: "RSA4096 key type",
+			args: args{
+				kt: wrapping.RSA4096,
+			},
+			want: keyvault.RSAHSM,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &Wrapper{}
+			if got := v.keyTypeToKty(tt.args.kt); got != tt.want {
+				t.Errorf("keyTypeToKty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

This PR adds an Azure Key Vault implementation of the `LifecycleWrapper` methods. This enables lifecycle management of RSA keys in Azure Key Vault using the library. See the acceptance test in this PR for an example usage of the library.

The `ImportKey` method implements the Azure Key Vault [BYOK specification](https://docs.microsoft.com/en-us/azure/key-vault/keys/byok-specification). See comments in the code for more specific details about steps in the specification.

## Related PRs

- https://github.com/hashicorp/go-kms-wrapping/pull/25

## Testing

### Acceptance

This PR includes an acceptance test which exercises each of the `LifecycleWrapper` method implementations. This test directly interacts with Azure Key Vault APIs, so credentials are needed to run it.

Acceptance Test Output:
```sh
$ AZURE_CLIENT_ID=<redacted> AZURE_CLIENT_SECRET=<redacted> AZURE_TENANT_ID=<redacted> AZUREKEYVAULT_WRAPPER_VAULT_NAME=demo-keyvault-1 VAULT_ACC=1 go test -v -run TestAzureKeyVault_KeyLifecycle

=== RUN   TestAzureKeyVault_KeyLifecycle
--- PASS: TestAzureKeyVault_KeyLifecycle (9.63s)
PASS
ok      github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault     11.217s
```

### Unit

Some unit tests were also added to this PR.

<details>
<summary>Unit Test Output</summary>
<pre>
$ go test -v      
=== RUN   TestAzureKeyVault_SetConfig
--- SKIP: TestAzureKeyVault_SetConfig (0.00s)
=== RUN   TestAzureKeyVault_Lifecycle
--- SKIP: TestAzureKeyVault_Lifecycle (0.00s)
=== RUN   TestAzureKeyVault_KeyLifecycle
--- SKIP: TestAzureKeyVault_KeyLifecycle (0.00s)
=== RUN   Test_jwkToRSAPublicKey
=== RUN   Test_jwkToRSAPublicKey/nil_JSONWebKey
=== RUN   Test_jwkToRSAPublicKey/invalid_JSONWebKey_missing_N
=== RUN   Test_jwkToRSAPublicKey/invalid_JSONWebKey_missing_E
=== RUN   Test_jwkToRSAPublicKey/valid_JSONWebKey
=== RUN   Test_jwkToRSAPublicKey/valid_JSONWebKey#01
--- PASS: Test_jwkToRSAPublicKey (0.00s)
    --- PASS: Test_jwkToRSAPublicKey/nil_JSONWebKey (0.00s)
    --- PASS: Test_jwkToRSAPublicKey/invalid_JSONWebKey_missing_N (0.00s)
    --- PASS: Test_jwkToRSAPublicKey/invalid_JSONWebKey_missing_E (0.00s)
    --- PASS: Test_jwkToRSAPublicKey/valid_JSONWebKey (0.00s)
    --- PASS: Test_jwkToRSAPublicKey/valid_JSONWebKey#01 (0.00s)
=== RUN   TestWrapper_validateKMSKey
=== RUN   TestWrapper_validateKMSKey/valid_KMS_key_single-purpose
=== RUN   TestWrapper_validateKMSKey/valid_KMS_key_multi-purpose
=== RUN   TestWrapper_validateKMSKey/valid_KMS_key_multi-purpose#01
=== RUN   TestWrapper_validateKMSKey/valid_KMS_key_multi-purpose#02
=== RUN   TestWrapper_validateKMSKey/invalid_KMS_key_empty_purpose
=== RUN   TestWrapper_validateKMSKey/invalid_KMS_key_protection_level
=== RUN   TestWrapper_validateKMSKey/invalid_KMS_key_unsupported_type
=== RUN   TestWrapper_validateKMSKey/invalid_KMS_key_unsupported_purpose
--- PASS: TestWrapper_validateKMSKey (0.00s)
    --- PASS: TestWrapper_validateKMSKey/valid_KMS_key_single-purpose (0.00s)
    --- PASS: TestWrapper_validateKMSKey/valid_KMS_key_multi-purpose (0.00s)
    --- PASS: TestWrapper_validateKMSKey/valid_KMS_key_multi-purpose#01 (0.00s)
    --- PASS: TestWrapper_validateKMSKey/valid_KMS_key_multi-purpose#02 (0.00s)
    --- PASS: TestWrapper_validateKMSKey/invalid_KMS_key_empty_purpose (0.00s)
    --- PASS: TestWrapper_validateKMSKey/invalid_KMS_key_protection_level (0.00s)
    --- PASS: TestWrapper_validateKMSKey/invalid_KMS_key_unsupported_type (0.00s)
    --- PASS: TestWrapper_validateKMSKey/invalid_KMS_key_unsupported_purpose (0.00s)
=== RUN   TestWrapper_keyPurposesToKeyOps
=== RUN   TestWrapper_keyPurposesToKeyOps/empty_purpose
=== RUN   TestWrapper_keyPurposesToKeyOps/unsupported_purpose
=== RUN   TestWrapper_keyPurposesToKeyOps/single_purpose
=== RUN   TestWrapper_keyPurposesToKeyOps/multiple_purposes
--- PASS: TestWrapper_keyPurposesToKeyOps (0.00s)
    --- PASS: TestWrapper_keyPurposesToKeyOps/empty_purpose (0.00s)
    --- PASS: TestWrapper_keyPurposesToKeyOps/unsupported_purpose (0.00s)
    --- PASS: TestWrapper_keyPurposesToKeyOps/single_purpose (0.00s)
    --- PASS: TestWrapper_keyPurposesToKeyOps/multiple_purposes (0.00s)
=== RUN   TestWrapper_keyTypeToKty
=== RUN   TestWrapper_keyTypeToKty/empty_key_type
=== RUN   TestWrapper_keyTypeToKty/RSA2048_key_type
=== RUN   TestWrapper_keyTypeToKty/RSA3072_key_type
=== RUN   TestWrapper_keyTypeToKty/RSA4096_key_type
--- PASS: TestWrapper_keyTypeToKty (0.00s)
    --- PASS: TestWrapper_keyTypeToKty/empty_key_type (0.00s)
    --- PASS: TestWrapper_keyTypeToKty/RSA2048_key_type (0.00s)
    --- PASS: TestWrapper_keyTypeToKty/RSA3072_key_type (0.00s)
    --- PASS: TestWrapper_keyTypeToKty/RSA4096_key_type (0.00s)
PASS
ok      github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault     0.162s
</pre>
</details>