### PR TITLE
Use option to not require a key when configuring the AWS KMS wrapper

### DIFF
--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -34,12 +34,13 @@ const (
 // Wrapper represents credentials and Key information for the KMS Key used to
 // encryption and decryption
 type Wrapper struct {
-	accessKey    string
-	secretKey    string
-	sessionToken string
-	region       string
-	keyID        string
-	endpoint     string
+	accessKey      string
+	secretKey      string
+	sessionToken   string
+	region         string
+	keyID          string
+	endpoint       string
+	keyNotRequired bool
 
 	currentKeyID *atomic.Value
 
@@ -57,8 +58,9 @@ func NewWrapper(opts *wrapping.WrapperOptions) *Wrapper {
 		opts = new(wrapping.WrapperOptions)
 	}
 	k := &Wrapper{
-		currentKeyID: new(atomic.Value),
-		logger:       opts.Logger,
+		currentKeyID:   new(atomic.Value),
+		logger:         opts.Logger,
+		keyNotRequired: opts.KeyNotRequired,
 	}
 	k.currentKeyID.Store("")
 	return k
@@ -85,6 +87,8 @@ func (k *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 		k.keyID = os.Getenv(EnvVaultAWSKMSSealKeyID)
 	case config["kms_key_id"] != "":
 		k.keyID = config["kms_key_id"]
+	case k.keyNotRequired:
+		// key not required to set config
 	default:
 		return nil, fmt.Errorf("'kms_key_id' not found for AWS KMS wrapper configuration")
 	}
@@ -115,17 +119,19 @@ func (k *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 			return nil, fmt.Errorf("error initializing AWS KMS wrapping client: %w", err)
 		}
 
-		// Test the client connection using provided key ID
-		keyInfo, err := client.DescribeKey(&kms.DescribeKeyInput{
-			KeyId: aws.String(k.keyID),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("error fetching AWS KMS wrapping key information: %w", err)
+		if !k.keyNotRequired {
+			// Test the client connection using provided key ID
+			keyInfo, err := client.DescribeKey(&kms.DescribeKeyInput{
+				KeyId: aws.String(k.keyID),
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error fetching AWS KMS wrapping key information: %w", err)
+			}
+			if keyInfo == nil || keyInfo.KeyMetadata == nil || keyInfo.KeyMetadata.KeyId == nil {
+				return nil, errors.New("no key information returned")
+			}
+			k.currentKeyID.Store(aws.StringValue(keyInfo.KeyMetadata.KeyId))
 		}
-		if keyInfo == nil || keyInfo.KeyMetadata == nil || keyInfo.KeyMetadata.KeyId == nil {
-			return nil, errors.New("no key information returned")
-		}
-		k.currentKeyID.Store(aws.StringValue(keyInfo.KeyMetadata.KeyId))
 
 		k.client = client
 	}
@@ -270,6 +276,11 @@ func (k *Wrapper) Decrypt(_ context.Context, in *wrapping.EncryptedBlobInfo, aad
 	}
 
 	return plaintext, nil
+}
+
+// Client returns the AWS KMS client used by the wrapper.
+func (k *Wrapper) Client() kmsiface.KMSAPI {
+	return k.client
 }
 
 // GetAWSKMSClient returns an instance of the KMS client.


### PR DESCRIPTION
This PR adds usage of the `WrapperOptions.KeyNotRequired` option to the AWS KMS wrapper. Current clients of the wrapper will not experience a behavior change, as the default value requires the key ID to be provided. This is similar to what's currently in the Azure Key Vault wrapper on [azurekeyvault.go#L46](https://github.com/hashicorp/go-kms-wrapping/blob/master/wrappers/azurekeyvault/azurekeyvault.go#L46).

Additionally, this PR adds a getter for the AWS KMS wrapper client. This is similar to what's currently in the Azure Key Vault wrapper on [azurekeyvault.go#L301](https://github.com/hashicorp/go-kms-wrapping/blob/master/wrappers/azurekeyvault/azurekeyvault.go#L301).