### PR TITLE
Bump to oracle version using go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/vault/api v1.1.1
 	github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4
-	github.com/oracle/oci-go-sdk v12.5.0+incompatible
+	github.com/oracle/oci-go-sdk/v40 v40.4.0
 	github.com/stretchr/testify v1.6.1
 	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162
 	github.com/yandex-cloud/go-genproto v0.0.0-20200722140432-762fe965ce77

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/oracle/oci-go-sdk v12.5.0+incompatible h1:pr08ECoaDKHWO9tnzJB1YqClEs7ZK1CFOez2DQocH14=
-github.com/oracle/oci-go-sdk v12.5.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
+github.com/oracle/oci-go-sdk/v40 v40.4.0 h1:WxLh9S0nBMZ96zkcfZZJ/+F5g7nMi8d6M8/7lO0UKPY=
+github.com/oracle/oci-go-sdk/v40 v40.4.0/go.mod h1:61MwFx5gJGmavyXFWvB2aXzhrgwU42mY1gm1EZYJJ78=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=

--- a/wrappers/ocikms/ocikms.go
+++ b/wrappers/ocikms/ocikms.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping"
-	"github.com/oracle/oci-go-sdk/common"
-	"github.com/oracle/oci-go-sdk/common/auth"
-	"github.com/oracle/oci-go-sdk/keymanagement"
+	"github.com/oracle/oci-go-sdk/v40/common"
+	"github.com/oracle/oci-go-sdk/v40/common/auth"
+	"github.com/oracle/oci-go-sdk/v40/keymanagement"
 )
 
 const (


### PR DESCRIPTION
This bumps to the oracle version that uses go modules.

See https://github.com/hashicorp/go-kms-wrapping/pull/33 for more context.