### PR TITLE
fixed tencentcloud tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,8 @@ require (
 	github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4
 	github.com/oracle/oci-go-sdk v12.5.0+incompatible
 	github.com/stretchr/testify v1.6.1
-	github.com/tencentcloud/tencentcloud-sdk-go v1.0.162
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.233
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.233
 	github.com/yandex-cloud/go-genproto v0.0.0-20200722140432-762fe965ce77
 	github.com/yandex-cloud/go-sdk v0.0.0-20200722140627-2194e5077f13
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9

--- a/go.sum
+++ b/go.sum
@@ -369,8 +369,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 h1:8fDzz4GuVg4skjY2B0nMN7h6uN61EDVkuLyI2+qGHhI=
-github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.233 h1:IfgUIheDKm+U82xZ3QPN7i4q1iMlIE0kODFTCpasEVg=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.233/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.233 h1:xrjsOGSWCHCMLveFV7ojmIN4J4gFMAirqF+wbWsnxls=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.233/go.mod h1:yrBKWhChnDqNz1xuXdSbWXG56XawEq0G5j1lg4VwBD4=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/yandex-cloud/go-genproto v0.0.0-20200722140432-762fe965ce77 h1:ujojfQqu+1XfDMOVzAcKIJ3pRSF5f3gAmVGxuLcFWn4=

--- a/wrappers/tencentcloudkms/tencentcloudkms_test.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms_test.go
@@ -85,19 +85,22 @@ type mockTencentCloudKMSWrapperClient struct {
 }
 
 // Encrypt is a mocked call that returns a base64 encoded string.
-func (m *mockTencentCloudKMSWrapperClient) Encrypt(request *kms.EncryptRequest) (response *kms.EncryptResponse, err error) {
+func (m *mockTencentCloudKMSWrapperClient) Encrypt(request *kms.EncryptRequest) (
+	response *kms.EncryptResponse, err error) {
 	m.keyID = request.KeyId
 
 	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(*request.Plaintext)))
 	base64.StdEncoding.Encode(encoded, []byte(*request.Plaintext))
 
 	output := &kms.EncryptResponse{}
-	_ = output.FromJsonString(`{"Response": {"KeyId": "` + *request.KeyId + `", "CiphertextBlob": "` + string(encoded) + `"}}`)
+	_ = output.FromJsonString(`{"Response": {"KeyId": "` + *request.KeyId +
+		`", "CiphertextBlob": "` + string(encoded) + `"}}`)
 	return output, nil
 }
 
 // Decrypt is a mocked call that returns a decoded base64 string.
-func (m *mockTencentCloudKMSWrapperClient) Decrypt(request *kms.DecryptRequest) (response *kms.DecryptResponse, err error) {
+func (m *mockTencentCloudKMSWrapperClient) Decrypt(request *kms.DecryptRequest) (
+	response *kms.DecryptResponse, err error) {
 	decLen := base64.StdEncoding.DecodedLen(len(*request.CiphertextBlob))
 	decoded := make([]byte, decLen)
 	len, err := base64.StdEncoding.Decode(decoded, []byte(*request.CiphertextBlob))
@@ -115,7 +118,8 @@ func (m *mockTencentCloudKMSWrapperClient) Decrypt(request *kms.DecryptRequest) 
 }
 
 // DescribeKey is a mocked call that returns the keyID.
-func (m *mockTencentCloudKMSWrapperClient) DescribeKey(request *kms.DescribeKeyRequest) (response *kms.DescribeKeyResponse, err error) {
+func (m *mockTencentCloudKMSWrapperClient) DescribeKey(request *kms.DescribeKeyRequest) (
+	response *kms.DescribeKeyResponse, err error) {
 	if *m.keyID == "" {
 		return nil, errors.New("key not found")
 	}


### PR DESCRIPTION
This PR only fix the tag of tencentcloud.
I have test it and passed.

```
KMS_ACC_TESTS=on go test -v ./...
=== RUN   TestAccTencentCloudKMSWrapper_Lifecycle
--- PASS: TestAccTencentCloudKMSWrapper_Lifecycle (0.56s)
=== RUN   TestTencentCloudKMSWrapper
--- PASS: TestTencentCloudKMSWrapper (0.00s)
=== RUN   TestTencentCloudKMSWrapper_Lifecycle
--- PASS: TestTencentCloudKMSWrapper_Lifecycle (0.00s)
PASS
ok      github.com/hashicorp/go-kms-wrapping/wrappers/tencentcloudkms   0.569s
```