### PR TITLE
gcpckms: Adds method for getting the relative resource name of the configured key ring

### DIFF
--- a/wrappers/gcpckms/gcpckms.go
+++ b/wrappers/gcpckms/gcpckms.go
@@ -303,3 +303,8 @@ func (s *Wrapper) createClient() (*cloudkms.KeyManagementClient, error) {
 
 	return client, nil
 }
+
+// KeyRingResourceName returns the relative resource name of the configured key ring.
+func (s *Wrapper) KeyRingResourceName() string {
+	return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", s.project, s.location, s.keyRing)
+}


### PR DESCRIPTION
This PR adds a method to the `gcpckms` wrapper for obtaining the [relative resource name](https://cloud.google.com/apis/design/resource_names#relative_resource_name) of the configured [Key Ring](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings#KeyRing).