### PR TITLE
Always set currentKeyID in SetConfig

### DIFF
--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -98,6 +98,8 @@ func (k *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 		return nil, fmt.Errorf("'kms_key_id' not found for AWS KMS wrapper configuration")
 	}
 
+	k.currentKeyID.Store(k.keyID)
+
 	// Please see GetRegion for an explanation of the order in which region is parsed.
 	var err error
 	k.region, err = awsutil.GetRegion(config["region"])

--- a/wrappers/awskms/awskms_test.go
+++ b/wrappers/awskms/awskms_test.go
@@ -28,6 +28,20 @@ func TestAWSKMSWrapper(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if s.KeyID() != awsTestKeyID {
+		t.Fatalf("Expected key ID %s, got %s", awsTestKeyID, s.KeyID())
+	}
+
+	newKeyID := "new-key"
+	config := make(map[string]string)
+	config["kms_key_id"] = newKeyID
+	os.Setenv(EnvAWSKMSWrapperKeyID, "")
+	_, err = s.SetConfig(config)
+
+	if s.KeyID() != "new-key" {
+		t.Fatalf("Expected key ID %s, got %s", newKeyID, s.KeyID())
+	}
 }
 
 func TestAWSKMSWrapper_Lifecycle(t *testing.T) {


### PR DESCRIPTION
This adds a line to make sure that `currentKeyID` is always set when `SetConfig` is called, so that calls to the `KeyID()` function will return the correct key ID when `keyNotRequired` is `true`.