### PR TITLE
Add the ability for a Azure/AWS wrapper to ignore environment variables

### DIFF
--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -80,20 +81,17 @@ func NewWrapper(opts *wrapping.WrapperOptions) *Wrapper {
 // * Instance metadata role (access key and secret key)
 // * Default values
 func (k *Wrapper) SetConfig(config map[string]string) (map[string]string, error) {
-	return k.SetConfigWithEnv(config, true)
-}
-
-// SetConfigWithEnv sets the various fields on the Wrapper object, with the ability to
-// either ignore or use environment variables within the system.
-//
-// Order of precedence AWS values:
-// * Environment variable (ignored if allowEnv is false)
-// * Passed in config map
-// * Instance metadata role (access key and secret key)
-// * Default values
-func (k *Wrapper) SetConfigWithEnv(config map[string]string, allowEnv bool) (map[string]string, error) {
 	if config == nil {
 		config = map[string]string{}
+	}
+
+	allowEnv := true
+	if val, ok := config["disallow_env_vars"]; ok {
+		disallowEnvVars, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+		allowEnv = !disallowEnvVars
 	}
 
 	// Check and set KeyID

--- a/wrappers/awskms/awskms_test.go
+++ b/wrappers/awskms/awskms_test.go
@@ -43,13 +43,14 @@ func TestAWSKMSWrapper_IgnoreEnv(t *testing.T) {
 	}
 
 	config := map[string]string{
-		"kms_key_id": "a-key-key",
-		"access_key": "a-access-key",
-		"secret_key": "a-secret-key",
-		"endpoint":   "my-endpoint",
+		"disallow_env_vars": "true",
+		"kms_key_id":        "a-key-key",
+		"access_key":        "a-access-key",
+		"secret_key":        "a-secret-key",
+		"endpoint":          "my-endpoint",
 	}
 
-	_, err := wrapper.SetConfigWithEnv(config, false)
+	_, err := wrapper.SetConfig(config)
 	assert.NoError(t, err)
 
 	require.Equal(t, config["access_key"], wrapper.accessKey)

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -70,35 +70,49 @@ func NewWrapper(opts *wrapping.WrapperOptions) *Wrapper {
 //
 // Order of precedence:
 // * Environment variable
-// * Value from Vault configuration file
+// * Passed in config map
 // * Managed Service Identity for instance
 func (v *Wrapper) SetConfig(config map[string]string) (map[string]string, error) {
+	return v.SetConfigWithEnv(config, true)
+}
+
+// SetConfigWithEnv sets the various fields on the Wrapper object, with the ability to
+// either ignore or use environment variables within the system.
+//
+// Order of precedence:
+// * Environment variable (ignored if allowEnv is false)
+// * Passed in config map
+// * Managed Service Identity for instance
+func (v *Wrapper) SetConfigWithEnv(config map[string]string, allowEnv bool) (map[string]string, error) {
 	if config == nil {
 		config = map[string]string{}
 	}
 
 	switch {
-	case os.Getenv("AZURE_TENANT_ID") != "":
+	case os.Getenv("AZURE_TENANT_ID") != "" && allowEnv:
 		v.tenantID = os.Getenv("AZURE_TENANT_ID")
 	case config["tenant_id"] != "":
 		v.tenantID = config["tenant_id"]
 	}
 
 	switch {
-	case os.Getenv("AZURE_CLIENT_ID") != "":
+	case os.Getenv("AZURE_CLIENT_ID") != "" && allowEnv:
 		v.clientID = os.Getenv("AZURE_CLIENT_ID")
 	case config["client_id"] != "":
 		v.clientID = config["client_id"]
 	}
 
 	switch {
-	case os.Getenv("AZURE_CLIENT_SECRET") != "":
+	case os.Getenv("AZURE_CLIENT_SECRET") != "" && allowEnv:
 		v.clientSecret = os.Getenv("AZURE_CLIENT_SECRET")
 	case config["client_secret"] != "":
 		v.clientSecret = config["client_secret"]
 	}
 
-	envName := os.Getenv("AZURE_ENVIRONMENT")
+	var envName string
+	if allowEnv {
+		envName = os.Getenv("AZURE_ENVIRONMENT")
+	}
 	if envName == "" {
 		envName = config["environment"]
 	}
@@ -112,7 +126,10 @@ func (v *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 		}
 	}
 
-	azResource := os.Getenv("AZURE_AD_RESOURCE")
+	var azResource string
+	if allowEnv {
+		azResource = os.Getenv("AZURE_AD_RESOURCE")
+	}
 	if azResource == "" {
 		azResource = config["resource"]
 		if azResource == "" {
@@ -124,9 +141,9 @@ func (v *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 	v.environment.KeyVaultEndpoint = v.resource
 
 	switch {
-	case os.Getenv(EnvAzureKeyVaultWrapperVaultName) != "":
+	case os.Getenv(EnvAzureKeyVaultWrapperVaultName) != "" && allowEnv:
 		v.vaultName = os.Getenv(EnvAzureKeyVaultWrapperVaultName)
-	case os.Getenv(EnvVaultAzureKeyVaultVaultName) != "":
+	case os.Getenv(EnvVaultAzureKeyVaultVaultName) != "" && allowEnv:
 		v.vaultName = os.Getenv(EnvVaultAzureKeyVaultVaultName)
 	case config["vault_name"] != "":
 		v.vaultName = config["vault_name"]
@@ -135,9 +152,9 @@ func (v *Wrapper) SetConfig(config map[string]string) (map[string]string, error)
 	}
 
 	switch {
-	case os.Getenv(EnvAzureKeyVaultWrapperKeyName) != "":
+	case os.Getenv(EnvAzureKeyVaultWrapperKeyName) != "" && allowEnv:
 		v.keyName = os.Getenv(EnvAzureKeyVaultWrapperKeyName)
-	case os.Getenv(EnvVaultAzureKeyVaultKeyName) != "":
+	case os.Getenv(EnvVaultAzureKeyVaultKeyName) != "" && allowEnv:
 		v.keyName = os.Getenv(EnvVaultAzureKeyVaultKeyName)
 	case config["key_name"] != "":
 		v.keyName = config["key_name"]

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync/atomic"
 
@@ -73,19 +74,17 @@ func NewWrapper(opts *wrapping.WrapperOptions) *Wrapper {
 // * Passed in config map
 // * Managed Service Identity for instance
 func (v *Wrapper) SetConfig(config map[string]string) (map[string]string, error) {
-	return v.SetConfigWithEnv(config, true)
-}
-
-// SetConfigWithEnv sets the various fields on the Wrapper object, with the ability to
-// either ignore or use environment variables within the system.
-//
-// Order of precedence:
-// * Environment variable (ignored if allowEnv is false)
-// * Passed in config map
-// * Managed Service Identity for instance
-func (v *Wrapper) SetConfigWithEnv(config map[string]string, allowEnv bool) (map[string]string, error) {
 	if config == nil {
 		config = map[string]string{}
+	}
+
+	allowEnv := true
+	if val, ok := config["disallow_env_vars"]; ok {
+		disallowEnvVars, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, err
+		}
+		allowEnv = !disallowEnvVars
 	}
 
 	switch {

--- a/wrappers/azurekeyvault/azurekeyvault_acc_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_acc_test.go
@@ -5,6 +5,11 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAzureKeyVault_SetConfig(t *testing.T) {
@@ -28,6 +33,39 @@ func TestAzureKeyVault_SetConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestAzureKeyVault_IgnoreEnv(t *testing.T) {
+	s := NewWrapper(nil)
+	client := keyvault.New()
+	s.client = &client
+
+	// Setup environment values to ignore for the following values
+	for _, envVar := range []string{"AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET",
+		"AZURE_ENVIRONMENT", "AZURE_AD_RESOURCE", EnvAzureKeyVaultWrapperVaultName,
+		EnvVaultAzureKeyVaultVaultName, EnvAzureKeyVaultWrapperKeyName, EnvVaultAzureKeyVaultKeyName} {
+		oldVal := os.Getenv(envVar)
+		os.Setenv(envVar, "envValue")
+		defer os.Setenv(envVar, oldVal)
+	}
+	config := map[string]string{
+		"tenant_id":     "a-tenant-id",
+		"client_id":     "a-client-id",
+		"client_secret": "a-client-secret",
+		"environment":   azure.PublicCloud.Name,
+		"resource":      "a-resource",
+		"vault_name":    "a-vault-name",
+		"key_name":      "a-key-name",
+	}
+	_, err := s.SetConfigWithEnv(config, false)
+	assert.NoError(t, err)
+	require.Equal(t, config["tenant_id"], s.tenantID)
+	require.Equal(t, config["client_id"], s.clientID)
+	require.Equal(t, config["client_secret"], s.clientSecret)
+	require.Equal(t, config["environment"], s.environment.Name)
+	require.Equal(t, "https://"+config["resource"]+"/", s.resource)
+	require.Equal(t, config["vault_name"], s.vaultName)
+	require.Equal(t, config["key_name"], s.keyName)
 }
 
 func TestAzureKeyVault_Lifecycle(t *testing.T) {

--- a/wrappers/azurekeyvault/azurekeyvault_acc_test.go
+++ b/wrappers/azurekeyvault/azurekeyvault_acc_test.go
@@ -49,15 +49,16 @@ func TestAzureKeyVault_IgnoreEnv(t *testing.T) {
 		defer os.Setenv(envVar, oldVal)
 	}
 	config := map[string]string{
-		"tenant_id":     "a-tenant-id",
-		"client_id":     "a-client-id",
-		"client_secret": "a-client-secret",
-		"environment":   azure.PublicCloud.Name,
-		"resource":      "a-resource",
-		"vault_name":    "a-vault-name",
-		"key_name":      "a-key-name",
+		"disallow_env_vars": "true",
+		"tenant_id":         "a-tenant-id",
+		"client_id":         "a-client-id",
+		"client_secret":     "a-client-secret",
+		"environment":       azure.PublicCloud.Name,
+		"resource":          "a-resource",
+		"vault_name":        "a-vault-name",
+		"key_name":          "a-key-name",
 	}
-	_, err := s.SetConfigWithEnv(config, false)
+	_, err := s.SetConfig(config)
 	assert.NoError(t, err)
 	require.Equal(t, config["tenant_id"], s.tenantID)
 	require.Equal(t, config["client_id"], s.clientID)


### PR DESCRIPTION
 - A minimal change due to the v2 version actively being worked on to allow
   Vault to specify all the configuration parameters to either an Azure or
   AWS wrapper and ignore any environment variables that would be set/override 
   the provided values within the config map.
 - This is to allow the new Managed Key feature within Vault to specify the entire configuration 
   to a wrapper and not have an existing seal wrap environment var override configuration of the 
  managed key for example.
 - Relates to VAULT-5067