### PR TITLE
feature (extras/kms): add Repository functions

### DIFF
--- a/extras/kms/data_key_test.go
+++ b/extras/kms/data_key_test.go
@@ -1,0 +1,170 @@
+package kms
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-dbw"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewDataKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		rootKeyId       string
+		purpose         KeyPurpose
+		want            *DataKey
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-root-key-id",
+			purpose:         "database",
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing root key id",
+		},
+		{
+			name:            "missing-purpose",
+			rootKeyId:       "root-key-id",
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing purpose",
+		},
+		{
+			name:            "invalid-purpose",
+			rootKeyId:       "root-key-id",
+			purpose:         KeyPurposeRootKey,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: fmt.Sprintf("cannot be a purpose of %q", KeyPurposeRootKey),
+		},
+		{
+			name:      "valid",
+			rootKeyId: "root-key-id",
+			purpose:   "database",
+			want: &DataKey{
+				RootKeyId: "root-key-id",
+				Purpose:   "database",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := NewDataKey(tc.rootKeyId, tc.purpose)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestDataKey_vetForWrite(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	tests := []struct {
+		name            string
+		key             *DataKey
+		opType          dbw.OpType
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "create-missing-private-id",
+			key: &DataKey{
+				RootKeyId: "root-key-id",
+				Purpose:   "database",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "create-missing-root-key",
+			key: &DataKey{
+				PrivateId: "private-key-id",
+				Purpose:   "database",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing root key",
+		},
+		{
+			name: "create-invalid-purpose",
+			key: &DataKey{
+				PrivateId: "private-key-id",
+				RootKeyId: "root-key-id",
+				Purpose:   KeyPurposeRootKey,
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: fmt.Sprintf("cannot be a purpose of %q", KeyPurposeRootKey),
+		},
+		{
+			name: "create-missing-purpose",
+			key: &DataKey{
+				PrivateId: "private-key-id",
+				RootKeyId: "root-key-id",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing purpose",
+		},
+		{
+			name: "invalid-update",
+			key: &DataKey{
+				PrivateId: "private-key-id",
+				RootKeyId: "root-key-id",
+				Purpose:   "database",
+			},
+			opType:          dbw.UpdateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "data key is immutable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tc.key.vetForWrite(testCtx, tc.opType)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestDataKey_GetRootKeyId(t *testing.T) {
+	t.Parallel()
+	k := &DataKey{
+		RootKeyId: "root-key-id",
+	}
+	assert.Equal(t, "root-key-id", k.GetRootKeyId())
+}

--- a/extras/kms/data_key_version_test.go
+++ b/extras/kms/data_key_version_test.go
@@ -1,0 +1,296 @@
+package kms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewDataKeyVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		dataKeyId        string
+		rootKeyVersionId string
+		key              []byte
+		want             *DataKeyVersion
+		wantErr          bool
+		wantErrIs        error
+		wantErrContains  string
+	}{
+		{
+			name:             "missing-data-key-id",
+			rootKeyVersionId: "root-key-version-id",
+			key:              []byte("key"),
+			wantErr:          true,
+			wantErrIs:        ErrInvalidParameter,
+			wantErrContains:  "missing data key id",
+		},
+		{
+			name:            "missing-root-key-version-id",
+			dataKeyId:       "data-key-id",
+			key:             []byte("key"),
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing root key version id",
+		},
+		{
+			name:             "missing-key",
+			dataKeyId:        "data-key-id",
+			rootKeyVersionId: "root-key-version-id",
+			wantErr:          true,
+			wantErrIs:        ErrInvalidParameter,
+			wantErrContains:  "missing key",
+		},
+		{
+			name:             "valid",
+			dataKeyId:        "data-key-id",
+			rootKeyVersionId: "root-key-version-id",
+			key:              []byte("key"),
+			want: &DataKeyVersion{
+				DataKeyId:        "data-key-id",
+				RootKeyVersionId: "root-key-version-id",
+				Key:              []byte("key"),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := NewDataKeyVersion(tc.dataKeyId, tc.key, tc.rootKeyVersionId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestDataKeyVersion_vetForWrite(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	tests := []struct {
+		name            string
+		key             *DataKeyVersion
+		opType          dbw.OpType
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "create-missing-private-id",
+			key: &DataKeyVersion{
+				DataKeyId:        "data-key-id",
+				RootKeyVersionId: "root-key-version-id",
+				CtKey:            []byte("key"),
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "create-missing-ct-key",
+			key: &DataKeyVersion{
+				PrivateId:        "private-id",
+				DataKeyId:        "data-key-id",
+				RootKeyVersionId: "root-key-version-id",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name: "create-missing-data-key-id",
+			key: &DataKeyVersion{
+				PrivateId:        "private-id",
+				CtKey:            []byte("key"),
+				RootKeyVersionId: "root-key-version-id",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing data key id",
+		},
+		{
+			name: "create-missing-root-key-version-id",
+			key: &DataKeyVersion{
+				PrivateId: "private-id",
+				CtKey:     []byte("key"),
+				DataKeyId: "data-key-id",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing root key version id",
+		},
+		{
+			name: "update-immutable",
+			key: &DataKeyVersion{
+				PrivateId: "private-id",
+			},
+			opType:          dbw.UpdateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "key is immutable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tc.key.vetForWrite(testCtx, tc.opType)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestDataKeyVersion_Encrypt(t *testing.T) {
+	t.Parallel()
+	const (
+		testKey = "test-key"
+	)
+	testCtx := context.Background()
+	testWrapper := wrapping.NewTestWrapper([]byte(DefaultWrapperSecret))
+	tests := []struct {
+		name            string
+		key             *DataKeyVersion
+		wrapper         wrapping.Wrapper
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "bad-cipher",
+			key: &DataKeyVersion{
+				Key: []byte(testKey),
+			},
+			wrapper:         aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "error wrapping value",
+		},
+		{
+			name: "missing-cipher",
+			key: &DataKeyVersion{
+				Key: []byte(testKey),
+			},
+			wantErr:         true,
+			wantErrContains: "missing cipher",
+		},
+		{
+			name: "success",
+			key: &DataKeyVersion{
+				Key: []byte(testKey),
+			},
+			wrapper: testWrapper,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			require.Empty(tc.key.CtKey)
+			require.NotEmpty(tc.key.Key)
+			err := tc.key.Encrypt(testCtx, tc.wrapper)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotEmpty(tc.key.CtKey)
+			tc.key.Key = nil
+			err = tc.key.Decrypt(testCtx, tc.wrapper)
+			require.NoError(err)
+			assert.Equal(testKey, string(tc.key.Key))
+		})
+	}
+}
+
+func TestDataKeyVersion_Decrypt(t *testing.T) {
+	t.Parallel()
+	const (
+		testKey = "test-key"
+	)
+	testCtx := context.Background()
+	testWrapper := wrapping.NewTestWrapper([]byte(DefaultWrapperSecret))
+	testDataKey := &DataKeyVersion{
+		Key: []byte(testKey),
+	}
+	err := testDataKey.Encrypt(testCtx, testWrapper)
+	require.NoError(t, err)
+	tests := []struct {
+		name            string
+		key             *DataKeyVersion
+		wrapper         wrapping.Wrapper
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "bad-cipher",
+			key:             testDataKey,
+			wrapper:         aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "error unwrapping value",
+		},
+		{
+			name:            "missing-cipher",
+			key:             testDataKey,
+			wantErr:         true,
+			wantErrContains: "missing cipher",
+		},
+		{
+			name:    "success",
+			key:     testDataKey,
+			wrapper: testWrapper,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			require.NotEmpty(tc.key.CtKey)
+			require.NotEmpty(tc.key.Key)
+			err := tc.key.Decrypt(testCtx, tc.wrapper)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(testKey, string(tc.key.Key))
+		})
+	}
+}

--- a/extras/kms/errors.go
+++ b/extras/kms/errors.go
@@ -9,4 +9,11 @@ var (
 
 	// ErrInvalidParameter represents and invalid parameter error condition.
 	ErrInvalidParameter = errors.New("invalid parameter")
+
+	// ErrMultipleRecords represents multiple records were affected when only
+	// one was expected
+	ErrMultipleRecords = errors.New("multiple records")
+
+	// ErrRecordNotFound represents that no record was found
+	ErrRecordNotFound = errors.New("record not found")
 )

--- a/extras/kms/go.mod
+++ b/extras/kms/go.mod
@@ -5,8 +5,11 @@ go 1.17
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/golang-migrate/migrate/v4 v4.15.1
-	github.com/hashicorp/go-dbw v0.0.0-20220320124330-2bdfafa177a1
+	github.com/hashicorp/go-dbw v0.0.0-20220330205051-f8b3b24f5f9d
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.5-0.20220321175502-0989a9b6deb1
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
+	github.com/hashicorp/go-uuid v1.0.2
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	gorm.io/driver/postgres v1.2.2
 	mvdan.cc/gofumpt v0.3.0
@@ -20,7 +23,6 @@ require (
 	github.com/hashicorp/go-hclog v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 // indirect
-	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
@@ -38,6 +40,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/xo/dburl v0.9.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20220313003712-b769efc7c000 // indirect

--- a/extras/kms/go.sum
+++ b/extras/kms/go.sum
@@ -557,11 +557,13 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-dbw v0.0.0-20220320124330-2bdfafa177a1 h1:/zA499acTeKCYMpzdCFhcopQfrF2Ja6Dg+33ytWJaAM=
 github.com/hashicorp/go-dbw v0.0.0-20220320124330-2bdfafa177a1/go.mod h1:oh0okaxgqjJMPBSav3mSYPmyEbW7bVWQvRvkwJaQiIg=
+github.com/hashicorp/go-dbw v0.0.0-20220328164410-12672d831722 h1:52dlGgruhwG0XwcENAmlsLpVkOOlBSKvDBqp+zrfI7E=
+github.com/hashicorp/go-dbw v0.0.0-20220328164410-12672d831722/go.mod h1:w9gD0GS/RPaf1BQ//LmdWfQpW8SFwamwL1hmtzQ58p0=
+github.com/hashicorp/go-dbw v0.0.0-20220330205051-f8b3b24f5f9d h1:jcjwOmpjQRS84YijtP9RAFVnVUxrBLwS8363U/4VPfc=
+github.com/hashicorp/go-dbw v0.0.0-20220330205051-f8b3b24f5f9d/go.mod h1:w9gD0GS/RPaf1BQ//LmdWfQpW8SFwamwL1hmtzQ58p0=
 github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.4 h1:7BSAm60AqJom/TRb73wmaCzwco9A+Qolr/wCi0PORmY=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.4/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.5-0.20220321175502-0989a9b6deb1 h1:UFHzbA/voyzrVfxvm83LW6Hq2gd43F0mgchFnqrinjA=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.5-0.20220321175502-0989a9b6deb1/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -573,6 +575,8 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2 h1:ET4pqyjiGmY09R5y+rSd70J2w45CtbWDNvGqWp/R3Ng=
 github.com/hashicorp/go-secure-stdlib/base62 v0.1.2/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
+github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -924,6 +928,8 @@ github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThC
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
+github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/extras/kms/key_purpose.go
+++ b/extras/kms/key_purpose.go
@@ -1,0 +1,20 @@
+package kms
+
+// KeyPurpose allows an application to specify the reason they need a key; this
+// is used to select which DEK to return
+type KeyPurpose string
+
+const (
+	// KeyPurposeUnknown is the default, and indicates that a correct purpose
+	// wasn't specified
+	KeyPurposeUnknown KeyPurpose = ""
+
+	// KeyPurposeRootKey defines a root key purpose
+	KeyPurposeRootKey = "rootKey"
+)
+
+func reservedKeyPurpose() []string {
+	return []string{
+		string(KeyPurposeRootKey),
+	}
+}

--- a/extras/kms/kms.go
+++ b/extras/kms/kms.go
@@ -1,0 +1,13 @@
+package kms
+
+// Dek is an interface wrapping dek types to allow a lot less switching in loadDek
+type Dek interface {
+	GetRootKeyId() string
+	GetPrivateId() string
+}
+
+// DekVersion is an interface wrapping versioned dek types to allow a lot less switching in loadDek
+type DekVersion interface {
+	GetPrivateId() string
+	GetKey() []byte
+}

--- a/extras/kms/option.go
+++ b/extras/kms/option.go
@@ -76,7 +76,7 @@ func WithOrderByVersion(orderBy OrderBy) Option {
 }
 
 // WithRetryCount provides an optional specified retry count, otherwise the
-// StdRetryCnt is used.  You must specify WithRetryErrorsMatching if you want
+// StdRetryCnt is used. You must specify WithRetryErrorsMatching if you want
 // any retries at all.
 func WithRetryCount(cnt uint) Option {
 	return func(o *options) {

--- a/extras/kms/option.go
+++ b/extras/kms/option.go
@@ -21,10 +21,18 @@ type options struct {
 	withRepository     *Repository
 	withKeyId          string
 	withOrderByVersion OrderBy
+	withRetryCnt       uint
+	withErrorsMatching func(error) bool
+	withPurpose        KeyPurpose
 }
 
+var noOpErrorMatchingFn = func(error) bool { return false }
+
 func getDefaultOptions() options {
-	return options{}
+	return options{
+		withErrorsMatching: noOpErrorMatchingFn,
+		withRetryCnt:       StdRetryCnt,
+	}
 }
 
 // WithLimit provides an option to provide a limit. Intentionally allowing
@@ -64,5 +72,29 @@ func WithKeyId(keyId string) Option {
 func WithOrderByVersion(orderBy OrderBy) Option {
 	return func(o *options) {
 		o.withOrderByVersion = orderBy
+	}
+}
+
+// WithRetryCount provides an optional specified retry count, otherwise the
+// StdRetryCnt is used.  You must specify WithRetryErrorsMatching if you want
+// any retries at all.
+func WithRetryCount(cnt uint) Option {
+	return func(o *options) {
+		o.withRetryCnt = cnt
+	}
+}
+
+// WithRetryErrorsMatching provides an optional function to match transactions
+// errors which should be retried.
+func WithRetryErrorsMatching(matchingFn func(error) bool) Option {
+	return func(o *options) {
+		o.withErrorsMatching = matchingFn
+	}
+}
+
+// WithPurpose provides an optional key purpose
+func WithPurpose(purpose KeyPurpose) Option {
+	return func(o *options) {
+		o.withPurpose = purpose
 	}
 }

--- a/extras/kms/option_test.go
+++ b/extras/kms/option_test.go
@@ -1,6 +1,8 @@
 package kms
 
 import (
+	"reflect"
+	"runtime"
 	"testing"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
@@ -16,16 +18,22 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts()
 		testOpts := getDefaultOptions()
 		testOpts.withLimit = 0
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 
 		opts = getOpts(WithLimit(-1))
 		testOpts = getDefaultOptions()
 		testOpts.withLimit = -1
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 
 		opts = getOpts(WithLimit(1))
 		testOpts = getDefaultOptions()
 		testOpts.withLimit = 1
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 	})
 	t.Run("WithRootWrapper", func(t *testing.T) {
@@ -34,6 +42,8 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts(WithRootWrapper(testWrapper))
 		testOpts := getDefaultOptions()
 		testOpts.withRootWrapper = testWrapper
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 	})
 	t.Run("WithRepository", func(t *testing.T) {
@@ -44,6 +54,8 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts(WithRepository(testRepo))
 		testOpts := getDefaultOptions()
 		testOpts.withRepository = testRepo
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 	})
 	t.Run("WithKeyId", func(t *testing.T) {
@@ -51,6 +63,8 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts(WithKeyId("id"))
 		testOpts := getDefaultOptions()
 		testOpts.withKeyId = "id"
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 	})
 	t.Run("WithOrderByVersion", func(t *testing.T) {
@@ -58,6 +72,45 @@ func Test_GetOpts(t *testing.T) {
 		opts := getOpts(WithOrderByVersion(DescendingOrderBy))
 		testOpts := getDefaultOptions()
 		testOpts.withOrderByVersion = DescendingOrderBy
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithRetryErrorsMatching", func(t *testing.T) {
+		assert := assert.New(t)
+
+		// testing the default first...
+		opts := getOpts()
+		// using this pattern to test for equality: https://github.com/stretchr/testify/issues/182#issuecomment-495359313
+		funcName1 := runtime.FuncForPC(reflect.ValueOf(noOpErrorMatchingFn).Pointer()).Name()
+		funcName2 := runtime.FuncForPC(reflect.ValueOf(opts.withErrorsMatching).Pointer()).Name()
+		assert.Equal(funcName1, funcName2)
+
+		// now, we'll test an optional override
+		fn := func(error) bool { return true }
+		opts = getOpts(WithRetryErrorsMatching(fn))
+		funcName1 = runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+		funcName2 = runtime.FuncForPC(reflect.ValueOf(opts.withErrorsMatching).Pointer()).Name()
+		assert.Equal(funcName1, funcName2)
+	})
+	t.Run("WithRetryCount", func(t *testing.T) {
+		const cnt = 1000
+		assert := assert.New(t)
+		opts := getOpts(WithRetryCount(cnt))
+		testOpts := getDefaultOptions()
+		testOpts.withRetryCnt = cnt
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
+		assert.Equal(opts, testOpts)
+	})
+	t.Run("WithPurpose", func(t *testing.T) {
+		const purpose = "test-purpose"
+		assert := assert.New(t)
+		opts := getOpts(WithPurpose(purpose))
+		testOpts := getDefaultOptions()
+		testOpts.withPurpose = purpose
+		testOpts.withErrorsMatching = nil
+		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 	})
 }

--- a/extras/kms/repository.go
+++ b/extras/kms/repository.go
@@ -163,11 +163,11 @@ type KeyWithVersion struct {
 // easily accessed via their KeyPurpose
 type Keys map[KeyPurpose]KeyWithVersion
 
-// CreateKeysTx creates the root key and DEKs returns a map of the new keys.
+// CreateKeysTx creates the root key and DEKs and returns a map of the new keys.
 // This function encapsulates all the work required within a dbw.TxHandler and
 // allows this capability to be shared with other repositories or just called
 // within a transaction.  To be clear, this repository function doesn't include
-// it's own transaction and is intended to be used within a transaction provide
+// its own transaction and is intended to be used within a transaction provide
 // by the caller.
 func (r *Repository) CreateKeysTx(ctx context.Context, rootWrapper wrapping.Wrapper, randomReader io.Reader, scopeId string, purpose ...KeyPurpose) (Keys, error) {
 	const op = "kms.CreateKeysTx"

--- a/extras/kms/repository.go
+++ b/extras/kms/repository.go
@@ -3,9 +3,14 @@ package kms
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/hashicorp/go-dbw"
 	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/hashicorp/go-secure-stdlib/strutil"
+	"github.com/hashicorp/go-uuid"
 )
 
 const (
@@ -13,6 +18,12 @@ const (
 	DefaultLimit = 10000
 
 	DefaultWrapperSecret = "secret"
+
+	// StdRetryCnt defines a standard retry count for transactions.
+	StdRetryCnt = 20
+
+	// NoRowsAffected defines the returned value for no rows affected
+	NoRowsAffected = 0
 )
 
 // OrderBy defines an enum type for declaring a column's order by criteria.
@@ -48,6 +59,9 @@ func NewRepository(r dbw.Reader, w dbw.Writer, opt ...Option) (*Repository, erro
 	if w == nil {
 		return nil, fmt.Errorf("%s: nil writer: %w", op, ErrInvalidParameter)
 	}
+	if _, err := validateSchema(context.Background(), r); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
 	opts := getOpts(opt...)
 	if opts.withLimit == 0 {
 		// zero signals the boundary defaults should be used.
@@ -64,12 +78,164 @@ func NewRepository(r dbw.Reader, w dbw.Writer, opt ...Option) (*Repository, erro
 // required migrations.Version
 func (r *Repository) ValidateSchema(ctx context.Context) (string, error) {
 	const op = "kms.(Repository).validateVersion"
+	return validateSchema(ctx, r.reader)
+}
+
+func validateSchema(ctx context.Context, r dbw.Reader) (string, error) {
+	const op = "kms.validateSchema"
 	var s Schema
-	if err := r.reader.LookupWhere(ctx, &s, "1 = 1", nil); err != nil {
+	if err := r.LookupWhere(ctx, &s, "1=1", nil); err != nil {
 		return "", fmt.Errorf("%s: unable to get version: %w", op, err)
 	}
 	if s.Version != migrations.Version {
-		return s.Version, fmt.Errorf("%s: expected version %q and got %q: %w", op, migrations.Version, s.Version, ErrInvalidVersion)
+		return s.Version, fmt.Errorf("%s: invalid schema version, expected version %q and got %q: %w", op, migrations.Version, s.Version, ErrInvalidVersion)
 	}
 	return s.Version, nil
+}
+
+// DefaultLimit returns the default limit for listing as set on the repo
+func (r *Repository) DefaultLimit() int {
+	return r.defaultLimit
+}
+
+// list will return a listing of resources and honor the WithLimit option or the
+// repo defaultLimit.  WithOrderByVersion is supported for types that have a
+// version column
+func (r *Repository) list(ctx context.Context, resources interface{}, where string, args []interface{}, opt ...Option) error {
+	opts := getOpts(opt...)
+	limit := r.defaultLimit
+	var dbOpts []dbw.Option
+	if opts.withLimit != 0 {
+		// non-zero signals an override of the default limit for the repo.
+		limit = opts.withLimit
+	}
+	dbOpts = append(dbOpts, dbw.WithLimit(limit))
+	switch resources.(type) {
+	case *[]*RootKeyVersion, *[]*DataKeyVersion, []*RootKeyVersion, []*DataKeyVersion:
+		switch opts.withOrderByVersion {
+		case AscendingOrderBy:
+			dbOpts = append(dbOpts, dbw.WithOrder("version asc"))
+		case DescendingOrderBy:
+			dbOpts = append(dbOpts, dbw.WithOrder("version desc"))
+		}
+	}
+	return r.reader.SearchWhere(ctx, resources, where, args, dbOpts...)
+}
+
+type vetForWriter interface {
+	vetForWrite(ctx context.Context, opType dbw.OpType) error
+}
+
+func create(ctx context.Context, writer dbw.Writer, i interface{}, opt ...dbw.Option) error {
+	const op = "kms.(Repository).create"
+	before := func(interface{}) error { return nil }
+	if vetter, ok := i.(vetForWriter); ok {
+		before = func(i interface{}) error {
+			if err := vetter.vetForWrite(ctx, dbw.CreateOp); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
+	if before != nil {
+		opt = append(opt, dbw.WithBeforeWrite(before))
+	}
+	opt = append(opt, dbw.WithLookup(true))
+	if err := writer.Create(ctx, i, opt...); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+	return nil
+}
+
+// KeyIder defines a common interface for all keys contained within a
+// KeyWithVersion
+type KeyIder interface {
+	GetPrivateId() string
+}
+
+// KeyWithVersion encapsulates a key with its key version
+type KeyWithVersion struct {
+	Key        KeyIder
+	KeyVersion KeyIder
+}
+
+// Keys defines a return type for CreateKeysTx so the returned keys can be
+// easily accessed via their KeyPurpose
+type Keys map[KeyPurpose]KeyWithVersion
+
+// CreateKeysTx creates the root key and DEKs returns a map of the new keys.
+// This function encapsulates all the work required within a dbw.TxHandler and
+// allows this capability to be shared with other repositories or just called
+// within a transaction.  To be clear, this repository function doesn't include
+// it's own transaction and is intended to be used within a transaction provide
+// by the caller.
+func (r *Repository) CreateKeysTx(ctx context.Context, rootWrapper wrapping.Wrapper, randomReader io.Reader, scopeId string, purpose ...KeyPurpose) (Keys, error) {
+	const op = "kms.CreateKeysTx"
+	if rootWrapper == nil {
+		return nil, fmt.Errorf("%s: missing root wrapper: %w", op, ErrInvalidParameter)
+	}
+	if randomReader == nil {
+		return nil, fmt.Errorf("%s: missing random reader: %w", op, ErrInvalidParameter)
+	}
+	if scopeId == "" {
+		return nil, fmt.Errorf("%s: missing scope id: %w", op, ErrInvalidParameter)
+	}
+	reserved := reservedKeyPurpose()
+	dups := map[KeyPurpose]struct{}{}
+	for _, p := range purpose {
+		if strutil.StrListContains(reserved, string(p)) {
+			return nil, fmt.Errorf("%s: reserved key purpose %q: %w", op, p, ErrInvalidParameter)
+		}
+		if _, ok := dups[p]; ok {
+			return nil, fmt.Errorf("%s: duplicate key purpose %q: %w", op, p, ErrInvalidParameter)
+		}
+		dups[p] = struct{}{}
+	}
+	k, err := generateKey(ctx, randomReader)
+	if err != nil {
+		return nil, fmt.Errorf("%s: error generating random bytes for root key in scope %q: %w", op, scopeId, err)
+	}
+	rootKey, rootKeyVersion, err := createRootKeyTx(ctx, r.writer, rootWrapper, scopeId, k)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to create root key in scope %q: %w", op, scopeId, err)
+	}
+	keys := Keys{
+		KeyPurposeRootKey: KeyWithVersion{
+			rootKey,
+			rootKeyVersion,
+		},
+	}
+
+	rkvWrapper := aead.NewWrapper()
+	if _, err := rkvWrapper.SetConfig(ctx, wrapping.WithKeyId(rootKeyVersion.PrivateId)); err != nil {
+		return nil, fmt.Errorf("%s: error setting config on aead root wrapper in scope %q: %w", op, scopeId, err)
+	}
+	if err := rkvWrapper.SetAesGcmKeyBytes(rootKeyVersion.Key); err != nil {
+		return nil, fmt.Errorf("%s: error setting key bytes on aead root wrapper in scope %q: %w", op, scopeId, err)
+	}
+
+	for _, p := range purpose {
+		k, err = generateKey(ctx, randomReader)
+		if err != nil {
+			return nil, fmt.Errorf("%s: error generating random bytes for data key of purpose %q in scope %q: %w", op, p, scopeId, err)
+		}
+		dataKey, dataKeyVersion, err := createDataKeyTx(ctx, r.reader, r.writer, rkvWrapper, p, k)
+		if err != nil {
+			return nil, fmt.Errorf("%s: unable to create data key of purpose %q in scope %q: %w", op, p, scopeId, err)
+		}
+		keys[p] = KeyWithVersion{
+			Key:        dataKey,
+			KeyVersion: dataKeyVersion,
+		}
+	}
+	return keys, nil
+}
+
+func generateKey(ctx context.Context, randomReader io.Reader) ([]byte, error) {
+	const op = "kms.generateKey"
+	k, err := uuid.GenerateRandomBytesWithReader(32, randomReader)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return k, nil
 }

--- a/extras/kms/repository_data_key.go
+++ b/extras/kms/repository_data_key.go
@@ -1,0 +1,185 @@
+package kms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+)
+
+// CreateDataKey inserts into the repository and returns the new data key and
+// data key version. Supported options: WithRetryCnt, WithRetryErrorsMatching
+func (r *Repository) CreateDataKey(ctx context.Context, rkvWrapper wrapping.Wrapper, purpose KeyPurpose, key []byte, opt ...Option) (*DataKey, *DataKeyVersion, error) {
+	const op = "kms.(Repository).CreateDataKey"
+	opts := getOpts(opt...)
+	var returnedDk, returnedDv interface{}
+	_, err := r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(reader dbw.Reader, w dbw.Writer) error {
+			var err error
+			if returnedDk, returnedDv, err = createDataKeyTx(ctx, reader, w, rkvWrapper, purpose, key); err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: unable to create data key for purpose %q: %w", op, purpose, err)
+	}
+	return returnedDk.(*DataKey), returnedDv.(*DataKeyVersion), nil
+}
+
+// createDataKeyTx inserts into the db (via dbw.Writer) and returns the new data key
+// and data key version. This function encapsulates all the work required within
+// a dbw.TxHandler and allows this capability to be shared within this repository
+func createDataKeyTx(ctx context.Context, r dbw.Reader, w dbw.Writer, rkvWrapper wrapping.Wrapper, purpose KeyPurpose, key []byte) (*DataKey, *DataKeyVersion, error) {
+	const op = "kms.createDataKeyTx"
+	if rkvWrapper == nil {
+		return nil, nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	if purpose == KeyPurposeUnknown {
+		return nil, nil, fmt.Errorf("%s: missing purpose: %w", op, ErrInvalidParameter)
+	}
+	if len(key) == 0 {
+		return nil, nil, fmt.Errorf("%s: missing key: %w", op, ErrInvalidParameter)
+	}
+	rootKeyVersionId, err := rkvWrapper.KeyId(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: unable to lookup root key id: %w", op, err)
+	}
+	switch {
+	case rootKeyVersionId == "":
+		return nil, nil, fmt.Errorf("%s: missing root key version id: %w", op, ErrInvalidParameter)
+	case !strings.HasPrefix(rootKeyVersionId, RootKeyVersionPrefix):
+		return nil, nil, fmt.Errorf("%s: root key version id %q doesn't start with prefix %q: %w", op, rootKeyVersionId, RootKeyVersionPrefix, ErrInvalidParameter)
+	}
+	rv := RootKeyVersion{}
+	rv.PrivateId = rootKeyVersionId
+	err = r.LookupBy(ctx, &rv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: unable to lookup root key version %q: %w", op, rootKeyVersionId, err)
+	}
+
+	dk := DataKey{
+		Purpose: purpose,
+	}
+	dv := DataKeyVersion{}
+	id, err := newDataKeyId()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", op, err)
+	}
+	dk.PrivateId = id
+	dk.RootKeyId = rv.RootKeyId
+
+	id, err = newDataKeyVersionId()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", op, err)
+	}
+	dv.PrivateId = id
+	dv.DataKeyId = dk.PrivateId
+	dv.RootKeyVersionId = rootKeyVersionId
+	dv.Key = key
+	if err := dv.Encrypt(ctx, rkvWrapper); err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	// no oplog entries for keys
+	if err := create(ctx, w, &dk); err != nil {
+		return nil, nil, fmt.Errorf("%s: keys create: %w", op, err)
+	}
+	// no oplog entries for key versions
+	if err := create(ctx, w, &dv); err != nil {
+		return nil, nil, fmt.Errorf("%s: key versions create: %w", op, err)
+	}
+
+	return &dk, &dv, nil
+}
+
+// LookupDataKey will look up a key in the repository.  If the key is not
+// found, it will return nil, nil.
+func (r *Repository) LookupDataKey(ctx context.Context, privateId string, _ ...Option) (*DataKey, error) {
+	const op = "kms.(Repository).LookupDataKey"
+	if privateId == "" {
+		return nil, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	k := DataKey{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	return &k, nil
+}
+
+// DeleteDataKey deletes the key for the provided id from the
+// repository returning a count of the number of records deleted.  Supported
+// options: WithRetryCnt, WithRetryErrorsMatching
+func (r *Repository) DeleteDataKey(ctx context.Context, privateId string, opt ...Option) (int, error) {
+	const op = "kms.(Repository).DeleteDataKey"
+	if privateId == "" {
+		return NoRowsAffected, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	k := DataKey{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	opts := getOpts(opt...)
+
+	var rowsDeleted int
+	_, err := r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			dk := k.Clone()
+			// no oplog entries for root keys
+			rowsDeleted, err = w.Delete(ctx, dk)
+			if err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			if rowsDeleted > 1 {
+				return fmt.Errorf("%s: more than 1 resource would have been deleted: %w", op, ErrMultipleRecords)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	return rowsDeleted, nil
+}
+
+// ListDataKeys will list the keys.  Supports options: WithPurpose, WithLimit, WithOrderByVersion
+func (r *Repository) ListDataKeys(ctx context.Context, opt ...Option) ([]Dek, error) {
+	const op = "kms.(Repository).ListDataKeys"
+	var keys []*DataKey
+	where := "1=1"
+	var whereArgs []interface{}
+	opts := getOpts(opt...)
+	if opts.withPurpose != KeyPurposeUnknown {
+		where = "purpose = ?"
+		whereArgs = []interface{}{opts.withPurpose}
+	}
+	err := r.list(ctx, &keys, where, whereArgs, opt...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	deks := make([]Dek, 0, len(keys))
+	for _, key := range keys {
+		deks = append(deks, key)
+	}
+	return deks, nil
+}

--- a/extras/kms/repository_data_key_test.go
+++ b/extras/kms/repository_data_key_test.go
@@ -247,7 +247,6 @@ func TestRepository_DeleteDatabaseKey(t *testing.T) {
 	testCtx := context.Background()
 	db, _ := kms.TestDb(t)
 	rw := dbw.New(db)
-	// wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
 	testRepo, err := kms.NewRepository(rw, rw)
 	require.NoError(t, err)
 	const (
@@ -256,9 +255,6 @@ func TestRepository_DeleteDatabaseKey(t *testing.T) {
 	)
 	rk := kms.TestRootKey(t, db, testScopeId)
 
-	db.Debug(true)
-	type args struct {
-	}
 	tests := []struct {
 		name            string
 		repo            *kms.Repository

--- a/extras/kms/repository_data_key_test.go
+++ b/extras/kms/repository_data_key_test.go
@@ -1,0 +1,592 @@
+package kms_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/go-dbw"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTestWrapper struct {
+	wrapping.Wrapper
+	err   error
+	keyId string
+}
+
+func (m *mockTestWrapper) KeyId(context.Context) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.keyId, nil
+}
+
+func TestRepository_CreateDataKey(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+	rk := kms.TestRootKey(t, db, testScopeId)
+	rkv, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		purpose         kms.KeyPurpose
+		scopeId         string
+		key             []byte
+		keyWrapper      wrapping.Wrapper
+		opt             []kms.Option
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "nil-wrapper",
+			repo:            testRepo,
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      nil,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name:            "missing-purpose",
+			repo:            testRepo,
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing purpose",
+		},
+		{
+			name:            "missing-key",
+			repo:            testRepo,
+			purpose:         "database",
+			scopeId:         testScopeId,
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:            "empty-key",
+			repo:            testRepo,
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(""),
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:            "wrapper-key-id-error",
+			repo:            testRepo,
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      &mockTestWrapper{err: errors.New("KeyId error")},
+			wantErr:         true,
+			wantErrContains: "KeyId error",
+		},
+		{
+			name:            "wrapper-missing-key-id",
+			repo:            testRepo,
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "missing root key version id",
+		},
+		{
+			name:            "wrapper-invalid-key-id",
+			repo:            testRepo,
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      &mockTestWrapper{keyId: "invalid-key-id"},
+			wantErr:         true,
+			wantErrContains: "doesn't start with prefix",
+		},
+		{
+			name:    "encrypt-error",
+			repo:    testRepo,
+			purpose: "database",
+			scopeId: testScopeId,
+			key:     []byte(kms.DefaultWrapperSecret),
+			keyWrapper: func() wrapping.Wrapper {
+				w := aead.NewWrapper()
+				w.SetConfig(testCtx, wrapping.WithKeyId(rkv.PrivateId))
+				return w
+			}(),
+			wantErr:         true,
+			wantErrContains: "error wrapping value",
+		},
+		{
+			name: "lookup-root-key-version-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-root-key-version-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrContains: "lookup-root-key-version-error",
+		},
+		{
+			name: "create-data-key-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"private_id", "create_time"}).AddRow(rk.PrivateId, time.Now()))
+				mock.ExpectQuery(`INSERT INTO "kms_data_key"`).WillReturnError(errors.New("create-data-key-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrContains: "create-data-key-error",
+		},
+		{
+			name: "create-data-key-version-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"private_id", "root_key_id"}).AddRow(rkv.PrivateId, rkv.RootKeyId))
+				mock.ExpectQuery(`INSERT INTO`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"private_id", "create_time"}).AddRow(rk.PrivateId, time.Now()))
+				mock.ExpectQuery(`INSERT INTO`).WillReturnError(errors.New("create-data-key-version-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			purpose:         "database",
+			scopeId:         testScopeId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrContains: "create-data-key-version-error",
+		},
+		{
+			name:       "success",
+			repo:       testRepo,
+			purpose:    "database",
+			scopeId:    testScopeId,
+			key:        []byte(kms.DefaultWrapperSecret),
+			keyWrapper: rkvWrapper,
+			wantErr:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			dk, dv, err := tc.repo.CreateDataKey(context.Background(), tc.keyWrapper, tc.purpose, tc.key, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(dk.CreateTime)
+			foundKey, err := tc.repo.LookupDataKey(context.Background(), dk.PrivateId)
+			assert.NoError(err)
+			assert.Equal(dk, foundKey)
+
+			assert.NotNil(dv.CreateTime)
+			foundKeyVersion, err := tc.repo.LookupDataKeyVersion(context.Background(), tc.keyWrapper, dv.PrivateId)
+			assert.NoError(err)
+			assert.Equal(dv, foundKeyVersion)
+		})
+	}
+}
+
+func TestRepository_DeleteDatabaseKey(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	// wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	const (
+		testPurpose = "database"
+		testScopeId = "o_1234567890"
+	)
+	rk := kms.TestRootKey(t, db, testScopeId)
+
+	db.Debug(true)
+	type args struct {
+	}
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		key             *kms.DataKey
+		opt             []kms.Option
+		wantRowsDeleted int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "no-private-id",
+			key: func() *kms.DataKey {
+				k := kms.DataKey{}
+				return &k
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "not-found",
+			repo: testRepo,
+			key: func() *kms.DataKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrRecordNotFound,
+			wantErrContains: "not found",
+		},
+		{
+			name: "lookup-by-error",
+			key: func() *kms.DataKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-by-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "lookup-by-error",
+		},
+		{
+			name: "delete-error",
+			key: func() *kms.DataKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnError(errors.New("delete-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "delete-error",
+		},
+		{
+			name: "delete-too-many-error",
+			key: func() *kms.DataKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrMultipleRecords,
+			wantErrContains: "multiple records",
+		},
+		{
+			name:            "valid",
+			repo:            testRepo,
+			key:             kms.TestDataKey(t, db, rk.PrivateId, testPurpose),
+			wantRowsDeleted: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			deletedRows, err := tc.repo.DeleteDataKey(testCtx, tc.key.PrivateId, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantRowsDeleted, deletedRows)
+			foundKey, err := tc.repo.LookupDataKey(context.Background(), tc.key.PrivateId)
+			assert.Error(err)
+			assert.Nil(foundKey)
+			assert.ErrorIs(err, kms.ErrRecordNotFound)
+		})
+	}
+}
+
+func TestRepository_ListDataKeys(t *testing.T) {
+	const (
+		testLimit   = 10
+		testPurpose = "database"
+		testScopeId = "o_1234567890"
+	)
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw, kms.WithLimit(testLimit))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		opt             []kms.Option
+		createCnt       int
+		wantCnt         int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:      "no-limit",
+			repo:      testRepo,
+			createCnt: testLimit * 2,
+			opt:       []kms.Option{kms.WithLimit(-1)},
+			wantCnt:   testLimit * 2,
+			wantErr:   false,
+		},
+		{
+			name:      "default-limit",
+			repo:      testRepo,
+			createCnt: testLimit + 5,
+			wantCnt:   testLimit,
+		},
+		{
+			name:      "custom-limit",
+			repo:      testRepo,
+			createCnt: testLimit + 1,
+			opt:       []kms.Option{kms.WithLimit(3)},
+			wantCnt:   3,
+			wantErr:   false,
+		},
+		{
+			name:      "WithOrderByVersion",
+			repo:      testRepo,
+			createCnt: testLimit * 5,
+			opt:       []kms.Option{kms.WithOrderByVersion(kms.AscendingOrderBy)},
+			wantCnt:   testLimit,
+		},
+		{
+			name:      "WithPurpose",
+			repo:      testRepo,
+			createCnt: testLimit * 5,
+			opt:       []kms.Option{kms.WithPurpose("not-found")},
+			wantCnt:   0,
+		},
+		{
+			name:      "WithPurpose",
+			repo:      testRepo,
+			createCnt: testLimit * 5,
+			opt:       []kms.Option{kms.WithPurpose(kms.KeyPurpose(fmt.Sprintf("%s-1", testPurpose)))},
+			wantCnt:   1,
+		},
+		{
+			name: "list-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("list-error"))
+				return r
+			}(),
+			createCnt:       testLimit,
+			wantErr:         true,
+			wantErrContains: "list-error",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.RootKey{}; return &i }(), "1=1")
+			rk := kms.TestRootKey(t, db, testScopeId)
+			_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+			for i := 0; i < tc.createCnt; i++ {
+				_, _, err := testRepo.CreateDataKey(testCtx, rkvWrapper, kms.KeyPurpose(fmt.Sprintf("%s-%d", testPurpose, i)), []byte(kms.DefaultWrapperSecret))
+				require.NoError(err)
+			}
+			got, err := tc.repo.ListDataKeys(context.Background(), tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantCnt, len(got))
+		})
+	}
+}
+
+func TestRepository_LookupDataKey(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		privateKeyId    string
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-private-id",
+			repo:            testRepo,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "lookup-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-error"))
+				return r
+			}(),
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrContains: "lookup-error",
+		},
+		{
+			name: "success",
+			repo: testRepo,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				rk := kms.TestRootKey(t, db, id)
+				_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+				dk, _, err := testRepo.CreateDataKey(testCtx, rkvWrapper, "database", []byte(kms.DefaultWrapperSecret))
+				require.NoError(t, err)
+				return dk.PrivateId
+			}(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := tc.repo.LookupDataKey(testCtx, tc.privateKeyId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.privateKeyId, got.PrivateId)
+		})
+	}
+}

--- a/extras/kms/repository_data_key_version.go
+++ b/extras/kms/repository_data_key_version.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CreateDataKeyVersion inserts into the repository and returns the new key
-// version with its PrivateId.  Supported options: WithRetryCnt,
+// version with its PrivateId. Supported options: WithRetryCnt,
 // WithRetryErrorsMatching
 func (r *Repository) CreateDataKeyVersion(ctx context.Context, rkvWrapper wrapping.Wrapper, dataKeyId string, key []byte, opt ...Option) (*DataKeyVersion, error) {
 	const op = "kms.(Repository).CreateDataKeyVersion"
@@ -33,7 +33,6 @@ func (r *Repository) CreateDataKeyVersion(ctx context.Context, rkvWrapper wrappi
 		return nil, fmt.Errorf("%s: missing root key version id: %w", op, ErrInvalidParameter)
 	case !strings.HasPrefix(rootKeyVersionId, RootKeyVersionPrefix):
 		return nil, fmt.Errorf("%s: root key version id %q doesn't start with prefix %q: %w", op, rootKeyVersionId, RootKeyVersionPrefix, ErrInvalidParameter)
-
 	}
 	kv := DataKeyVersion{}
 	id, err := newDataKeyVersionId()
@@ -70,8 +69,8 @@ func (r *Repository) CreateDataKeyVersion(ctx context.Context, rkvWrapper wrappi
 	return returnedKey.(*DataKeyVersion), nil
 }
 
-// LookupDataKeyVersion will look up a key version in the repository.  If
-// the key version is not found, it will return nil, nil.
+// LookupDataKeyVersion will look up a key version in the repository. If
+// the key version is not found then an ErrRecordNotFound will be returned.
 func (r *Repository) LookupDataKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, privateId string, _ ...Option) (*DataKeyVersion, error) {
 	const op = "kms.(Repository).LookupDatabaseKeyVersion"
 	if privateId == "" {
@@ -138,8 +137,8 @@ func (r *Repository) DeleteDataKeyVersion(ctx context.Context, privateId string,
 }
 
 // LatestDataKeyVersion searches for the key version with the highest
-// version number.  When no results are found, it returns nil with an
-// errors.RecordNotFound error.
+// version number. When no results are found, it returns nil with an
+// ErrRecordNotFound error.
 func (r *Repository) LatestDataKeyVersion(ctx context.Context, rkvWrapper wrapping.Wrapper, dataKeyId string, _ ...Option) (*DataKeyVersion, error) {
 	const op = "kms.(Repository).LatestDataKeyVersion"
 	if dataKeyId == "" {
@@ -161,7 +160,7 @@ func (r *Repository) LatestDataKeyVersion(ctx context.Context, rkvWrapper wrappi
 	return foundKeys[0], nil
 }
 
-// // ListDataKeyVersions will lists versions of a key.  Supported options:
+// ListDataKeyVersions will lists versions of a key. Supported options:
 // WithLimit, WithOrderByVersion
 func (r *Repository) ListDataKeyVersions(ctx context.Context, rkvWrapper wrapping.Wrapper, databaseKeyId string, opt ...Option) ([]DekVersion, error) {
 	const op = "kms.(Repository).ListDataVersions"

--- a/extras/kms/repository_data_key_version.go
+++ b/extras/kms/repository_data_key_version.go
@@ -1,0 +1,189 @@
+package kms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+)
+
+// CreateDataKeyVersion inserts into the repository and returns the new key
+// version with its PrivateId.  Supported options: WithRetryCnt,
+// WithRetryErrorsMatching
+func (r *Repository) CreateDataKeyVersion(ctx context.Context, rkvWrapper wrapping.Wrapper, dataKeyId string, key []byte, opt ...Option) (*DataKeyVersion, error) {
+	const op = "kms.(Repository).CreateDataKeyVersion"
+	if rkvWrapper == nil {
+		return nil, fmt.Errorf("%s: missing root key version wrapper: %w", op, ErrInvalidParameter)
+	}
+	if dataKeyId == "" {
+		return nil, fmt.Errorf("%s: missing data key id: %w", op, ErrInvalidParameter)
+	}
+	if len(key) == 0 {
+		return nil, fmt.Errorf("%s: missing key: %w", op, ErrInvalidParameter)
+	}
+	rootKeyVersionId, err := rkvWrapper.KeyId(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: unable to get key id: %w", op, err)
+	}
+	switch {
+	case rootKeyVersionId == "":
+		return nil, fmt.Errorf("%s: missing root key version id: %w", op, ErrInvalidParameter)
+	case !strings.HasPrefix(rootKeyVersionId, RootKeyVersionPrefix):
+		return nil, fmt.Errorf("%s: root key version id %q doesn't start with prefix %q: %w", op, rootKeyVersionId, RootKeyVersionPrefix, ErrInvalidParameter)
+
+	}
+	kv := DataKeyVersion{}
+	id, err := newDataKeyVersionId()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	kv.PrivateId = id
+	kv.RootKeyVersionId = rootKeyVersionId
+	kv.Key = key
+	kv.DataKeyId = dataKeyId
+	if err := kv.Encrypt(ctx, rkvWrapper); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	opts := getOpts(opt...)
+
+	var returnedKey interface{}
+	_, err = r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) error {
+			returnedKey = kv.Clone()
+			// no oplog entries for root key version
+			if err := create(ctx, w, returnedKey); err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed for %q data key id: %w", op, kv.DataKeyId, err)
+	}
+	return returnedKey.(*DataKeyVersion), nil
+}
+
+// LookupDataKeyVersion will look up a key version in the repository.  If
+// the key version is not found, it will return nil, nil.
+func (r *Repository) LookupDataKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, privateId string, _ ...Option) (*DataKeyVersion, error) {
+	const op = "kms.(Repository).LookupDatabaseKeyVersion"
+	if privateId == "" {
+		return nil, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	k := DataKeyVersion{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	if err := k.Decrypt(ctx, keyWrapper); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return &k, nil
+}
+
+// DeleteDataKeyVersion deletes the key version for the provided id from the
+// repository returning a count of the number of records deleted. Supported
+// options: WithRetryCnt, WithRetryErrorsMatching
+func (r *Repository) DeleteDataKeyVersion(ctx context.Context, privateId string, opt ...Option) (int, error) {
+	const op = "kms.(Repository).DeleteDataKeyVersion"
+	if privateId == "" {
+		return NoRowsAffected, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	k := DataKeyVersion{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	opts := getOpts(opt...)
+
+	var rowsDeleted int
+	_, err := r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			dk := k.Clone()
+			// no oplog entries for the key version
+			rowsDeleted, err = w.Delete(ctx, dk)
+			if err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			if rowsDeleted > 1 {
+				return fmt.Errorf("%s: more than 1 resource would have been deleted: %w", op, ErrMultipleRecords)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	return rowsDeleted, nil
+}
+
+// LatestDataKeyVersion searches for the key version with the highest
+// version number.  When no results are found, it returns nil with an
+// errors.RecordNotFound error.
+func (r *Repository) LatestDataKeyVersion(ctx context.Context, rkvWrapper wrapping.Wrapper, dataKeyId string, _ ...Option) (*DataKeyVersion, error) {
+	const op = "kms.(Repository).LatestDataKeyVersion"
+	if dataKeyId == "" {
+		return nil, fmt.Errorf("%s: missing data key id: %w", op, ErrInvalidParameter)
+	}
+	if rkvWrapper == nil {
+		return nil, fmt.Errorf("%s: missing root key version wrapper: %w", op, ErrInvalidParameter)
+	}
+	var foundKeys []*DataKeyVersion
+	if err := r.reader.SearchWhere(ctx, &foundKeys, "data_key_id = ?", []interface{}{dataKeyId}, dbw.WithLimit(1), dbw.WithOrder("version desc")); err != nil {
+		return nil, fmt.Errorf("%s: failed for %q: %w", op, dataKeyId, err)
+	}
+	if len(foundKeys) == 0 {
+		return nil, fmt.Errorf("%s: %w", op, ErrRecordNotFound)
+	}
+	if err := foundKeys[0].Decrypt(ctx, rkvWrapper); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return foundKeys[0], nil
+}
+
+// // ListDataKeyVersions will lists versions of a key.  Supported options:
+// WithLimit, WithOrderByVersion
+func (r *Repository) ListDataKeyVersions(ctx context.Context, rkvWrapper wrapping.Wrapper, databaseKeyId string, opt ...Option) ([]DekVersion, error) {
+	const op = "kms.(Repository).ListDataVersions"
+	if databaseKeyId == "" {
+		return nil, fmt.Errorf("%s: missing data key id: %w", op, ErrInvalidParameter)
+	}
+	if rkvWrapper == nil {
+		return nil, fmt.Errorf("%s: missing root key version wrapper: %w", op, ErrInvalidParameter)
+	}
+	var versions []*DataKeyVersion
+	err := r.list(ctx, &versions, "data_key_id = ?", []interface{}{databaseKeyId}, opt...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	for i, k := range versions {
+		if err := k.Decrypt(ctx, rkvWrapper); err != nil {
+			return nil, fmt.Errorf("%s: error decrypting key num %q: %w", op, i, err)
+		}
+	}
+	dekVersions := make([]DekVersion, 0, len(versions))
+	for _, version := range versions {
+		dekVersions = append(dekVersions, version)
+	}
+	return dekVersions, nil
+}

--- a/extras/kms/repository_data_key_version_test.go
+++ b/extras/kms/repository_data_key_version_test.go
@@ -190,8 +190,6 @@ func TestRepository_DeleteDataKeyVersion(t *testing.T) {
 	_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
 	dk := kms.TestDataKey(t, db, rk.PrivateId, testPurpose)
 
-	type args struct {
-	}
 	tests := []struct {
 		name            string
 		repo            *kms.Repository

--- a/extras/kms/repository_data_key_version_test.go
+++ b/extras/kms/repository_data_key_version_test.go
@@ -1,0 +1,727 @@
+package kms_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/go-dbw"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepository_CreateDataKeyVersion(t *testing.T) {
+	const (
+		testScopeId = "o_1234567890"
+		testPurpose = "database"
+	)
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	rk := kms.TestRootKey(t, db, testScopeId)
+	rkv, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+	dk := kms.TestDataKey(t, db, rk.PrivateId, testPurpose)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		key             []byte
+		dataKeyId       string
+		keyWrapper      wrapping.Wrapper
+		opt             []kms.Option
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "nil-wrapper",
+			repo:            testRepo,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      nil,
+			dataKeyId:       dk.PrivateId,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key version wrapper",
+		},
+		{
+			name:            "missing-data-key-id",
+			repo:            testRepo,
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing data key id",
+		},
+		{
+			name:            "missing-key",
+			repo:            testRepo,
+			keyWrapper:      rkvWrapper,
+			dataKeyId:       dk.PrivateId,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:            "empty-key",
+			repo:            testRepo,
+			keyWrapper:      rkvWrapper,
+			dataKeyId:       dk.PrivateId,
+			key:             []byte(""),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:            "wrapper-key-id-error",
+			repo:            testRepo,
+			keyWrapper:      &mockTestWrapper{err: errors.New("KeyId error")},
+			dataKeyId:       dk.PrivateId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			wantErr:         true,
+			wantErrContains: "KeyId error",
+		},
+		{
+			name:            "missing-root-key-version-id",
+			repo:            testRepo,
+			keyWrapper:      aead.NewWrapper(),
+			dataKeyId:       dk.PrivateId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key version id",
+		},
+		{
+			name: "invalid-root-key-version-id",
+			repo: testRepo,
+			keyWrapper: func() wrapping.Wrapper {
+				w := aead.NewWrapper()
+				w.SetConfig(testCtx, wrapping.WithKeyId("invalid-root-key-version-id"))
+				return w
+			}(), dataKeyId: dk.PrivateId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "doesn't start with prefix",
+		},
+		{
+			name: "encrypt-error",
+			repo: testRepo,
+			keyWrapper: func() wrapping.Wrapper {
+				w := aead.NewWrapper()
+				w.SetConfig(testCtx, wrapping.WithKeyId(rkv.PrivateId))
+				return w
+			}(), dataKeyId: dk.PrivateId,
+			key:             []byte(kms.DefaultWrapperSecret),
+			wantErr:         true,
+			wantErrContains: "error wrapping value",
+		},
+		{
+			name: "create-dkv-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				testRepo, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`INSERT INTO "kms_data_key_version"`).WillReturnError(errors.New("create-dkv-error"))
+				mock.ExpectRollback()
+				return testRepo
+			}(),
+			key:             []byte(kms.DefaultWrapperSecret),
+			keyWrapper:      rkvWrapper,
+			dataKeyId:       dk.PrivateId,
+			wantErr:         true,
+			wantErrContains: "create-dkv-error",
+		},
+		{
+			name:       "valid",
+			repo:       testRepo,
+			key:        []byte(kms.DefaultWrapperSecret),
+			keyWrapper: rkvWrapper,
+			dataKeyId:  dk.PrivateId,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			k, err := tc.repo.CreateDataKeyVersion(context.Background(), tc.keyWrapper, tc.dataKeyId, tc.key, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(k.CreateTime)
+			foundKey, err := tc.repo.LookupDataKeyVersion(context.Background(), tc.keyWrapper, k.PrivateId)
+			assert.NoError(err)
+			assert.Equal(k, foundKey)
+		})
+	}
+}
+
+func TestRepository_DeleteDataKeyVersion(t *testing.T) {
+	const (
+		testScopeId = "o_1234567890"
+		testPurpose = "database"
+	)
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	rk := kms.TestRootKey(t, db, testScopeId)
+	_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+	dk := kms.TestDataKey(t, db, rk.PrivateId, testPurpose)
+
+	type args struct {
+	}
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		key             *kms.DataKeyVersion
+		opt             []kms.Option
+		wantRowsDeleted int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "no-private-id",
+			repo: testRepo,
+			key: func() *kms.DataKeyVersion {
+				return &kms.DataKeyVersion{}
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "not-found",
+			repo: testRepo,
+			key: func() *kms.DataKeyVersion {
+				id, err := dbw.NewId(kms.DataKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKeyVersion{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrRecordNotFound,
+			wantErrContains: "record not found",
+		},
+		{
+			name: "lookup-by-error",
+			key:  kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte(kms.DefaultWrapperSecret)),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-by-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "lookup-by-error",
+		},
+		{
+			name: "delete-error",
+			key: func() *kms.DataKeyVersion {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKeyVersion{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnError(errors.New("delete-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "delete-error",
+		},
+		{
+			name: "delete-too-many-error",
+			key: func() *kms.DataKeyVersion {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.DataKeyVersion{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrMultipleRecords,
+			wantErrContains: "multiple records",
+		},
+		{
+			name:            "success",
+			repo:            testRepo,
+			key:             kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte(kms.DefaultWrapperSecret)),
+			wantRowsDeleted: 1,
+			wantErr:         false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			deletedRows, err := tc.repo.DeleteDataKeyVersion(context.Background(), tc.key.PrivateId, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantRowsDeleted, deletedRows)
+			foundKey, err := tc.repo.LookupDataKeyVersion(context.Background(), wrapper, tc.key.PrivateId)
+			assert.Error(err)
+			assert.Nil(foundKey)
+			assert.ErrorIs(err, kms.ErrRecordNotFound)
+		})
+	}
+}
+
+func TestRepository_LatestDataKeyVersion(t *testing.T) {
+	const (
+		testScopeId = "o_1234567890"
+		testPurpose = "database"
+	)
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	rk := kms.TestRootKey(t, db, testScopeId)
+	_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+	dk := kms.TestDataKey(t, db, rk.PrivateId, testPurpose)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		createCnt       int
+		dataKeyId       string
+		keyWrapper      wrapping.Wrapper
+		wantVersion     uint32
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:        "5",
+			repo:        testRepo,
+			dataKeyId:   dk.PrivateId,
+			createCnt:   5,
+			keyWrapper:  rkvWrapper,
+			wantVersion: 5,
+		},
+		{
+			name:        "1",
+			repo:        testRepo,
+			dataKeyId:   dk.PrivateId,
+			createCnt:   1,
+			keyWrapper:  rkvWrapper,
+			wantVersion: 1,
+		},
+		{
+			name:            "0",
+			repo:            testRepo,
+			dataKeyId:       dk.PrivateId,
+			createCnt:       0,
+			keyWrapper:      rkvWrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrRecordNotFound,
+			wantErrContains: "not found",
+		},
+		{
+			name:            "missing-data-key-id",
+			repo:            testRepo,
+			createCnt:       5,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing data key id",
+		},
+		{
+			name:            "nil-wrapper",
+			repo:            testRepo,
+			dataKeyId:       dk.PrivateId,
+			createCnt:       5,
+			keyWrapper:      nil,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key version wrapper",
+		},
+		{
+			name: "search-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("search-error"))
+				return r
+			}(),
+			dataKeyId:       dk.PrivateId,
+			createCnt:       5,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrContains: "search-error",
+		},
+		{
+			name:            "bad-wrapper",
+			repo:            testRepo,
+			dataKeyId:       dk.PrivateId,
+			createCnt:       5,
+			keyWrapper:      aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "error unwrapping value",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.DataKeyVersion{}; return &i }(), "1=1")
+			testKeys := []*kms.DataKeyVersion{}
+			for i := 0; i < tc.createCnt; i++ {
+				k := kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte("test key"))
+				testKeys = append(testKeys, k)
+			}
+			assert.Equal(tc.createCnt, len(testKeys))
+			got, err := tc.repo.LatestDataKeyVersion(context.Background(), tc.keyWrapper, tc.dataKeyId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(tc.wantVersion, got.Version)
+		})
+	}
+}
+
+func TestRepository_ListDataKeyVersions(t *testing.T) {
+	const (
+		testLimit   = 10
+		testPurpose = "database"
+		testScopeId = "o_1234567890"
+	)
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw, kms.WithLimit(testLimit))
+	require.NoError(t, err)
+	rk := kms.TestRootKey(t, db, testScopeId)
+	_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+	dk := kms.TestDataKey(t, db, rk.PrivateId, testPurpose)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		dataKeyId       string
+		keyWrapper      wrapping.Wrapper
+		opt             []kms.Option
+		createCnt       int
+		wantCnt         int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:       "no-limit",
+			repo:       testRepo,
+			createCnt:  testLimit * 2,
+			dataKeyId:  dk.PrivateId,
+			keyWrapper: rkvWrapper,
+			opt:        []kms.Option{kms.WithLimit(-1)},
+			wantCnt:    testLimit * 2,
+		},
+		{
+			name:       "default-limit",
+			repo:       testRepo,
+			createCnt:  testLimit + 1,
+			keyWrapper: rkvWrapper,
+			dataKeyId:  dk.PrivateId,
+			wantCnt:    testLimit,
+		},
+		{
+			name:       "custom-limit",
+			repo:       testRepo,
+			createCnt:  testLimit + 1,
+			keyWrapper: rkvWrapper,
+			dataKeyId:  dk.PrivateId,
+			opt:        []kms.Option{kms.WithLimit(3)},
+			wantCnt:    3,
+		},
+		{
+			name:            "bad-wrapper",
+			repo:            testRepo,
+			createCnt:       1,
+			keyWrapper:      aead.NewWrapper(),
+			dataKeyId:       dk.PrivateId,
+			wantErr:         true,
+			wantErrContains: "error decrypting",
+		},
+		{
+			name:            "missing-data-key-id",
+			repo:            testRepo,
+			createCnt:       1,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing data key id",
+		},
+		{
+			name:            "missing-wrapper",
+			repo:            testRepo,
+			createCnt:       1,
+			keyWrapper:      nil,
+			dataKeyId:       dk.PrivateId,
+			wantCnt:         0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key version wrapper",
+		},
+		{
+			name: "list-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("list-error"))
+				return r
+			}(),
+			keyWrapper:      wrapper,
+			dataKeyId:       dk.PrivateId,
+			createCnt:       testLimit,
+			wantErr:         true,
+			wantErrContains: "list-error",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.DataKeyVersion{}; return &i }(), "1=1")
+			keyVersions := []*kms.DataKeyVersion{}
+			for i := 0; i < tc.createCnt; i++ {
+				k := kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte("data key"))
+				keyVersions = append(keyVersions, k)
+			}
+			assert.Equal(tc.createCnt, len(keyVersions))
+			got, err := tc.repo.ListDataKeyVersions(context.Background(), tc.keyWrapper, tc.dataKeyId, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantCnt, len(got))
+		})
+	}
+	t.Run("order-by", func(t *testing.T) {
+		const createCnt = 10
+		assert, require := assert.New(t), require.New(t)
+		kms.TestDeleteWhere(t, db, func() interface{} { i := kms.DataKeyVersion{}; return &i }(), "1=1")
+		keyVersions := []*kms.DataKeyVersion{}
+		for i := 0; i < createCnt; i++ {
+			k := kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte("data key"))
+			keyVersions = append(keyVersions, k)
+		}
+		assert.Equal(createCnt, len(keyVersions))
+		got, err := testRepo.ListDataKeyVersions(context.Background(), wrapper, dk.PrivateId, kms.WithOrderByVersion(kms.DescendingOrderBy))
+		require.NoError(err)
+		assert.NotNil(got)
+		lastVersion := -1
+		for _, dkv := range got {
+			if lastVersion != -1 {
+				currentVersion := dkv.(*kms.DataKeyVersion).Version
+				assert.Greater(lastVersion, lastVersion)
+				lastVersion = int(currentVersion)
+			}
+		}
+
+		got, err = testRepo.ListDataKeyVersions(context.Background(), wrapper, dk.PrivateId, kms.WithOrderByVersion(kms.AscendingOrderBy))
+		require.NoError(err)
+		assert.NotNil(got)
+		lastVersion = -1
+		for _, dkv := range got {
+			if lastVersion != -1 {
+				currentVersion := dkv.(*kms.DataKeyVersion).Version
+				assert.Less(lastVersion, lastVersion)
+				lastVersion = int(currentVersion)
+			}
+		}
+	})
+}
+
+func TestRepository_LookupDataKeyVersion(t *testing.T) {
+	const (
+		testPurpose = "database"
+		testScopeId = "o_1234567890"
+	)
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	rk := kms.TestRootKey(t, db, testScopeId)
+	_, rkvWrapper := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+	dk := kms.TestDataKey(t, db, rk.PrivateId, testPurpose)
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		wrapper         wrapping.Wrapper
+		privateKeyId    string
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-private-id",
+			repo:            testRepo,
+			wrapper:         wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "missing-wrapper",
+			repo: testRepo,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name: "lookup-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-error"))
+				return r
+			}(),
+			wrapper: wrapper,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrContains: "lookup-error",
+		},
+		{
+			name:    "bad-wrapper",
+			repo:    testRepo,
+			wrapper: aead.NewWrapper(),
+			privateKeyId: func() string {
+				k := kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte("data key"))
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrContains: "error unwrapping value",
+		},
+		{
+			name:    "success",
+			repo:    testRepo,
+			wrapper: wrapper,
+			privateKeyId: func() string {
+				k := kms.TestDataKeyVersion(t, db, rkvWrapper, dk.PrivateId, []byte("data key"))
+				return k.PrivateId
+			}(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := tc.repo.LookupDataKeyVersion(testCtx, tc.wrapper, tc.privateKeyId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.privateKeyId, got.PrivateId)
+		})
+	}
+}

--- a/extras/kms/repository_root_key.go
+++ b/extras/kms/repository_root_key.go
@@ -1,0 +1,156 @@
+package kms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+)
+
+// CreateRootKey inserts into the repository and returns the new root key and
+// root key version. Supported options: WithRetryCnt, WithRetryErrorsMatching
+func (r *Repository) CreateRootKey(ctx context.Context, keyWrapper wrapping.Wrapper, scopeId string, key []byte, opt ...Option) (*RootKey, *RootKeyVersion, error) {
+	const op = "kms.(Repository).CreateRootKey"
+	opts := getOpts(opt...)
+	var returnedRk, returnedKv interface{}
+	_, err := r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) error {
+			var err error
+			if returnedRk, returnedKv, err = createRootKeyTx(ctx, w, keyWrapper, scopeId, key); err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: failed for %q: %w", op, scopeId, err)
+	}
+	return returnedRk.(*RootKey), returnedKv.(*RootKeyVersion), nil
+}
+
+// createRootKeyTx inserts into the db (via dbw.Writer) and returns the new root key
+// and root key version. This function encapsulates all the work required within
+// a dbw.TxHandler
+func createRootKeyTx(ctx context.Context, w dbw.Writer, keyWrapper wrapping.Wrapper, scopeId string, key []byte) (*RootKey, *RootKeyVersion, error) {
+	const op = "kms.createRootKeyTx"
+	if scopeId == "" {
+		return nil, nil, fmt.Errorf("%s: missing scope id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	if len(key) == 0 {
+		return nil, nil, fmt.Errorf("%s: missing key: %w", op, ErrInvalidParameter)
+	}
+	rk := RootKey{}
+	kv := RootKeyVersion{}
+	id, err := newRootKeyId()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", op, err)
+	}
+	rk.PrivateId = id
+	rk.ScopeId = scopeId
+
+	id, err = newRootKeyVersionId()
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", op, err)
+	}
+	kv.PrivateId = id
+	kv.RootKeyId = rk.PrivateId
+	kv.Key = key
+	if err := kv.Encrypt(ctx, keyWrapper); err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	if err := create(ctx, w, &rk); err != nil {
+		return nil, nil, fmt.Errorf("%s: root keys: %w", op, err)
+	}
+	if err := create(ctx, w, &kv); err != nil {
+		return nil, nil, fmt.Errorf("%s: key versions: %w", op, err)
+	}
+
+	return &rk, &kv, nil
+}
+
+// LookupRootKey will look up a root key in the repository.  If the key is not
+// found, it will return nil, nil.
+func (r *Repository) LookupRootKey(ctx context.Context, keyWrapper wrapping.Wrapper, privateId string, _ ...Option) (*RootKey, error) {
+	const op = "kms.(Repository).LookupRootKey"
+	if privateId == "" {
+		return nil, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	k := RootKey{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	return &k, nil
+}
+
+// DeleteRootKey deletes the root key for the provided id from the
+// repository returning a count of the number of records deleted.  Supported
+// options: WithRetryCnt, WithRetryErrorsMatching
+func (r *Repository) DeleteRootKey(ctx context.Context, privateId string, opt ...Option) (int, error) {
+	const op = "kms.(Repository).DeleteRootKey"
+	if privateId == "" {
+		return NoRowsAffected, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	k := RootKey{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+
+	opts := getOpts(opt...)
+
+	var rowsDeleted int
+	_, err := r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			dk := k.Clone()
+			// no oplog entries for root keys
+			rowsDeleted, err = w.Delete(ctx, dk)
+			if err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			if rowsDeleted > 1 {
+				return fmt.Errorf("%s: more than 1 resource would have been deleted: %w", op, ErrMultipleRecords)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	return rowsDeleted, nil
+}
+
+// ListRootKeys will list the root keys.  Supported options: WithLimit,
+// WithOrderByVersion
+func (r *Repository) ListRootKeys(ctx context.Context, opt ...Option) ([]*RootKey, error) {
+	const op = "kms.(Repository).ListRootKeys"
+	var keys []*RootKey
+	err := r.list(ctx, &keys, "1=1", nil, opt...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return keys, nil
+}

--- a/extras/kms/repository_root_key.go
+++ b/extras/kms/repository_root_key.go
@@ -14,7 +14,8 @@ import (
 func (r *Repository) CreateRootKey(ctx context.Context, keyWrapper wrapping.Wrapper, scopeId string, key []byte, opt ...Option) (*RootKey, *RootKeyVersion, error) {
 	const op = "kms.(Repository).CreateRootKey"
 	opts := getOpts(opt...)
-	var returnedRk, returnedKv interface{}
+	var returnedRk *RootKey
+	var returnedKv *RootKeyVersion
 	_, err := r.writer.DoTx(
 		ctx,
 		opts.withErrorsMatching,
@@ -31,7 +32,7 @@ func (r *Repository) CreateRootKey(ctx context.Context, keyWrapper wrapping.Wrap
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s: failed for %q: %w", op, scopeId, err)
 	}
-	return returnedRk.(*RootKey), returnedKv.(*RootKeyVersion), nil
+	return returnedRk, returnedKv, nil
 }
 
 // createRootKeyTx inserts into the db (via dbw.Writer) and returns the new root key
@@ -78,8 +79,8 @@ func createRootKeyTx(ctx context.Context, w dbw.Writer, keyWrapper wrapping.Wrap
 	return &rk, &kv, nil
 }
 
-// LookupRootKey will look up a root key in the repository.  If the key is not
-// found, it will return nil, nil.
+// LookupRootKey will look up a root key in the repository. If the key is not
+// found then an ErrRecordNotFound will be returned.
 func (r *Repository) LookupRootKey(ctx context.Context, keyWrapper wrapping.Wrapper, privateId string, _ ...Option) (*RootKey, error) {
 	const op = "kms.(Repository).LookupRootKey"
 	if privateId == "" {
@@ -100,7 +101,7 @@ func (r *Repository) LookupRootKey(ctx context.Context, keyWrapper wrapping.Wrap
 }
 
 // DeleteRootKey deletes the root key for the provided id from the
-// repository returning a count of the number of records deleted.  Supported
+// repository returning a count of the number of records deleted. Supported
 // options: WithRetryCnt, WithRetryErrorsMatching
 func (r *Repository) DeleteRootKey(ctx context.Context, privateId string, opt ...Option) (int, error) {
 	const op = "kms.(Repository).DeleteRootKey"
@@ -143,7 +144,7 @@ func (r *Repository) DeleteRootKey(ctx context.Context, privateId string, opt ..
 	return rowsDeleted, nil
 }
 
-// ListRootKeys will list the root keys.  Supported options: WithLimit,
+// ListRootKeys will list the root keys. Supported options: WithLimit,
 // WithOrderByVersion
 func (r *Repository) ListRootKeys(ctx context.Context, opt ...Option) ([]*RootKey, error) {
 	const op = "kms.(Repository).ListRootKeys"

--- a/extras/kms/repository_root_key_test.go
+++ b/extras/kms/repository_root_key_test.go
@@ -25,8 +25,6 @@ func TestRepository_CreateRootKey(t *testing.T) {
 	require.NoError(t, err)
 	testScopeId := "o_1234567890"
 
-	type args struct {
-	}
 	tests := []struct {
 		name            string
 		repo            *kms.Repository

--- a/extras/kms/repository_root_key_test.go
+++ b/extras/kms/repository_root_key_test.go
@@ -1,0 +1,590 @@
+package kms_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/go-dbw"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepository_CreateRootKey(t *testing.T) {
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+
+	type args struct {
+	}
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		scopeId         string
+		key             []byte
+		keyWrapper      wrapping.Wrapper
+		opt             []kms.Option
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-scope",
+			repo:            testRepo,
+			key:             []byte("empty-scope"),
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing scope",
+		},
+		{
+			name:            "nil-wrapper",
+			repo:            testRepo,
+			scopeId:         testScopeId,
+			key:             []byte("test key"),
+			keyWrapper:      nil,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name:            "missing-key",
+			repo:            testRepo,
+			scopeId:         testScopeId,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:            "bad-wrapper",
+			repo:            testRepo,
+			scopeId:         testScopeId,
+			key:             []byte("test key"),
+			keyWrapper:      aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "error wrapping value",
+		},
+		{
+			name: "create-rk-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				testRepo, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`INSERT INTO "kms_root_key"`).WillReturnError(errors.New("create-rk-error"))
+				mock.ExpectRollback()
+				return testRepo
+			}(),
+			scopeId:         testScopeId,
+			key:             []byte("test key"),
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrContains: "create-rk-error",
+		},
+		{
+			name: "create-rkv-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				testRepo, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`INSERT INTO "kms_root_key"`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectQuery(`INSERT INTO "kms_root_key_version"`).WillReturnError(errors.New("create-rkv-error"))
+				mock.ExpectRollback()
+				return testRepo
+			}(),
+			scopeId:         testScopeId,
+			key:             []byte("test key"),
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrContains: "create-rkv-error",
+		},
+		{
+			name:       "success",
+			repo:       testRepo,
+			scopeId:    testScopeId,
+			key:        []byte("test key"),
+			keyWrapper: wrapper,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			rk, kv, err := tc.repo.CreateRootKey(context.Background(), tc.keyWrapper, tc.scopeId, tc.key, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(rk.CreateTime)
+			foundKey, err := tc.repo.LookupRootKey(context.Background(), tc.keyWrapper, rk.PrivateId)
+			assert.NoError(err)
+			assert.Equal(rk, foundKey)
+
+			assert.NotNil(kv.CreateTime)
+			foundKeyVersion, err := tc.repo.LookupRootKeyVersion(context.Background(), tc.keyWrapper, kv.PrivateId)
+			assert.NoError(err)
+			assert.Equal(kv, foundKeyVersion)
+		})
+	}
+}
+
+func TestRepository_DeleteRootKey(t *testing.T) {
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		key             *kms.RootKey
+		opt             []kms.Option
+		wantRowsDeleted int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "no-private-id",
+			repo: testRepo,
+			key: func() *kms.RootKey {
+				return &kms.RootKey{}
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "not-found",
+			repo: testRepo,
+			key: func() *kms.RootKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKey{}
+				k.PrivateId = id
+				return &k
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrRecordNotFound,
+			wantErrContains: "record not found",
+		},
+		{
+			name: "lookup-by-error",
+			key: func() *kms.RootKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-by-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "lookup-by-error",
+		},
+		{
+			name: "delete-error",
+			key: func() *kms.RootKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnError(errors.New("delete-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "delete-error",
+		},
+		{
+			name: "delete-too-many-error",
+			key: func() *kms.RootKey {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKey{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrMultipleRecords,
+			wantErrContains: "multiple records",
+		},
+		{
+			name:            "valid",
+			repo:            testRepo,
+			key:             kms.TestRootKey(t, db, testScopeId),
+			wantRowsDeleted: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			deletedRows, err := tc.repo.DeleteRootKey(context.Background(), tc.key.PrivateId, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantRowsDeleted, deletedRows)
+			foundKey, err := tc.repo.LookupRootKey(context.Background(), wrapper, tc.key.PrivateId)
+			assert.Error(err)
+			assert.Nil(foundKey)
+			assert.ErrorIs(err, kms.ErrRecordNotFound)
+		})
+	}
+}
+
+func TestRepository_ListRootKeys(t *testing.T) {
+	const testLimit = 10
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw, kms.WithLimit(testLimit))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		createCnt       int
+		opt             []kms.Option
+		wantCnt         int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:      "no-limit",
+			repo:      testRepo,
+			createCnt: testLimit * 2,
+			opt:       []kms.Option{kms.WithLimit(-1)},
+			wantCnt:   testLimit * 2,
+		},
+		{
+			name:      "default-limit",
+			repo:      testRepo,
+			createCnt: testLimit + 5,
+			wantCnt:   testLimit,
+		},
+		{
+			name:      "custom-limit",
+			repo:      testRepo,
+			createCnt: testLimit + 1,
+			opt:       []kms.Option{kms.WithLimit(3)},
+			wantCnt:   3,
+			wantErr:   false,
+		},
+		{
+			name:      "ignored-option-WithOrderByVersion",
+			repo:      testRepo,
+			createCnt: testLimit * 5,
+			opt:       []kms.Option{kms.WithOrderByVersion(kms.AscendingOrderBy)},
+			wantCnt:   testLimit,
+		},
+		{
+			name: "list-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("list-error"))
+				return r
+			}(),
+			createCnt:       testLimit,
+			wantErr:         true,
+			wantErrContains: "list-error",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.RootKey{}; return &i }(), "1=1")
+			for i := 0; i < tc.createCnt; i++ {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(err)
+				_, _, err = testRepo.CreateRootKey(testCtx, wrapper, id, []byte(kms.DefaultWrapperSecret))
+				require.NoError(err)
+			}
+			got, err := tc.repo.ListRootKeys(context.Background(), tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantCnt, len(got))
+		})
+	}
+}
+
+func TestRepository_LookupRootKey(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		wrapper         wrapping.Wrapper
+		privateKeyId    string
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-private-id",
+			repo:            testRepo,
+			wrapper:         wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "missing-wrapper",
+			repo: testRepo,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name: "lookup-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-error"))
+				return r
+			}(),
+			wrapper: wrapper,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrContains: "lookup-error",
+		},
+		{
+			name:    "success",
+			repo:    testRepo,
+			wrapper: wrapper,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := tc.repo.LookupRootKey(testCtx, tc.wrapper, tc.privateKeyId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.privateKeyId, got.PrivateId)
+		})
+	}
+}
+
+func TestRepository_LookupRootKeyVersion(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+	rk := kms.TestRootKey(t, db, testScopeId)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		wrapper         wrapping.Wrapper
+		privateKeyId    string
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-private-id",
+			repo:            testRepo,
+			wrapper:         wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "missing-wrapper",
+			repo: testRepo,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name: "lookup-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-error"))
+				return r
+			}(),
+			wrapper: wrapper,
+			privateKeyId: func() string {
+				id, err := dbw.NewId("o")
+				require.NoError(t, err)
+				k := kms.TestRootKey(t, db, id)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrContains: "lookup-error",
+		},
+		{
+			name:    "bad-wrapper",
+			repo:    testRepo,
+			wrapper: aead.NewWrapper(),
+			privateKeyId: func() string {
+				k, _ := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+				return k.PrivateId
+			}(),
+			wantErr:         true,
+			wantErrContains: "unable to decrypt",
+		},
+		{
+			name:    "success",
+			repo:    testRepo,
+			wrapper: wrapper,
+			privateKeyId: func() string {
+				k, _ := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+				return k.PrivateId
+			}(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := tc.repo.LookupRootKeyVersion(testCtx, tc.wrapper, tc.privateKeyId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.privateKeyId, got.PrivateId)
+		})
+	}
+}

--- a/extras/kms/repository_root_key_version.go
+++ b/extras/kms/repository_root_key_version.go
@@ -9,8 +9,8 @@ import (
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 )
 
-// LookupRootKeyVersion will look up a root key version in the repository.  If
-// the key version is not found, it will return nil, nil.
+// LookupRootKeyVersion will look up a root key version in the repository. If
+// the key version is not found then an ErrRecordNotFound will be returned.
 func (r *Repository) LookupRootKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, privateId string, _ ...Option) (*RootKeyVersion, error) {
 	const op = "kms.(Repository).LookupRootKeyVersion"
 	if privateId == "" {
@@ -34,7 +34,7 @@ func (r *Repository) LookupRootKeyVersion(ctx context.Context, keyWrapper wrappi
 }
 
 // CreateRootKeyVersion inserts into the repository and returns the new root key
-// version with its PrivateId.  Supported options: WithRetryCnt,
+// version with its PrivateId. Supported options: WithRetryCnt,
 // WithRetryErrorsMatching
 func (r *Repository) CreateRootKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, rootKeyId string, key []byte, opt ...Option) (*RootKeyVersion, error) {
 	const op = "kms.(Repository).CreateRootKeyVersion"
@@ -82,7 +82,7 @@ func (r *Repository) CreateRootKeyVersion(ctx context.Context, keyWrapper wrappi
 }
 
 // DeleteRootKeyVersion deletes the root key version for the provided id from the
-// repository returning a count of the number of records deleted.  Supported
+// repository returning a count of the number of records deleted. Supported
 // options: WithRetryCnt, WithRetryErrorsMatching
 func (r *Repository) DeleteRootKeyVersion(ctx context.Context, privateId string, opt ...Option) (int, error) {
 	const op = "kms.(Repository).DeleteRootKeyVersion"
@@ -126,8 +126,8 @@ func (r *Repository) DeleteRootKeyVersion(ctx context.Context, privateId string,
 }
 
 // LatestRootKeyVersion searches for the root key version with the highest
-// version number.  When no results are found, it returns nil with an
-// errors.RecordNotFound error.
+// version number. When no results are found, it returns nil with an
+// ErrRecordNotFound error.
 func (r *Repository) LatestRootKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, rootKeyId string, _ ...Option) (*RootKeyVersion, error) {
 	const op = "kms.(Repository).LatestRootKeyVersion"
 	if rootKeyId == "" {
@@ -149,7 +149,7 @@ func (r *Repository) LatestRootKeyVersion(ctx context.Context, keyWrapper wrappi
 	return &foundKeys[0], nil
 }
 
-// ListRootKeyVersions in versions of a root key.  Supported options: WithLimit, WithOrderByVersion
+// ListRootKeyVersions in versions of a root key. Supported options: WithLimit, WithOrderByVersion
 func (r *Repository) ListRootKeyVersions(ctx context.Context, keyWrapper wrapping.Wrapper, rootKeyId string, opt ...Option) ([]*RootKeyVersion, error) {
 	const op = "kms.(Repository).ListRootKeyVersions"
 	if rootKeyId == "" {

--- a/extras/kms/repository_root_key_version.go
+++ b/extras/kms/repository_root_key_version.go
@@ -1,0 +1,172 @@
+package kms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+)
+
+// LookupRootKeyVersion will look up a root key version in the repository.  If
+// the key version is not found, it will return nil, nil.
+func (r *Repository) LookupRootKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, privateId string, _ ...Option) (*RootKeyVersion, error) {
+	const op = "kms.(Repository).LookupRootKeyVersion"
+	if privateId == "" {
+		return nil, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	k := RootKeyVersion{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return nil, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	if err := k.Decrypt(ctx, keyWrapper); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return &k, nil
+}
+
+// CreateRootKeyVersion inserts into the repository and returns the new root key
+// version with its PrivateId.  Supported options: WithRetryCnt,
+// WithRetryErrorsMatching
+func (r *Repository) CreateRootKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, rootKeyId string, key []byte, opt ...Option) (*RootKeyVersion, error) {
+	const op = "kms.(Repository).CreateRootKeyVersion"
+	if rootKeyId == "" {
+		return nil, fmt.Errorf("%s: missing root key id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	if len(key) == 0 {
+		return nil, fmt.Errorf("%s: missing key: %w", op, ErrInvalidParameter)
+	}
+	kv := RootKeyVersion{}
+	id, err := newRootKeyVersionId()
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	kv.PrivateId = id
+	kv.RootKeyId = rootKeyId
+	kv.Key = key
+	if err := kv.Encrypt(ctx, keyWrapper); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+
+	opts := getOpts(opt...)
+
+	var returnedKey interface{}
+	_, err = r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) error {
+			returnedKey = kv.Clone()
+			if err := create(ctx, w, returnedKey); err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%s: failed for %q root key id: %w", op, kv.RootKeyId, err)
+	}
+	return returnedKey.(*RootKeyVersion), nil
+}
+
+// DeleteRootKeyVersion deletes the root key version for the provided id from the
+// repository returning a count of the number of records deleted.  Supported
+// options: WithRetryCnt, WithRetryErrorsMatching
+func (r *Repository) DeleteRootKeyVersion(ctx context.Context, privateId string, opt ...Option) (int, error) {
+	const op = "kms.(Repository).DeleteRootKeyVersion"
+	if privateId == "" {
+		return NoRowsAffected, fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
+	}
+	k := RootKeyVersion{}
+	k.PrivateId = privateId
+	if err := r.reader.LookupBy(ctx, &k); err != nil {
+		if errors.Is(err, dbw.ErrRecordNotFound) {
+			return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, ErrRecordNotFound)
+		}
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+
+	opts := getOpts(opt...)
+
+	var rowsDeleted int
+	_, err := r.writer.DoTx(
+		ctx,
+		opts.withErrorsMatching,
+		opts.withRetryCnt,
+		dbw.ExpBackoff{},
+		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			dk := k.Clone()
+			// no oplog entries for root key version
+			rowsDeleted, err = w.Delete(ctx, dk)
+			if err != nil {
+				return fmt.Errorf("%s: %w", op, err)
+			}
+			if rowsDeleted > 1 {
+				return fmt.Errorf("%s: more than 1 resource would have been deleted: %w", op, ErrMultipleRecords)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return NoRowsAffected, fmt.Errorf("%s: failed for %q: %w", op, privateId, err)
+	}
+	return rowsDeleted, nil
+}
+
+// LatestRootKeyVersion searches for the root key version with the highest
+// version number.  When no results are found, it returns nil with an
+// errors.RecordNotFound error.
+func (r *Repository) LatestRootKeyVersion(ctx context.Context, keyWrapper wrapping.Wrapper, rootKeyId string, _ ...Option) (*RootKeyVersion, error) {
+	const op = "kms.(Repository).LatestRootKeyVersion"
+	if rootKeyId == "" {
+		return nil, fmt.Errorf("%s: missing root key id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	var foundKeys []RootKeyVersion
+	if err := r.reader.SearchWhere(ctx, &foundKeys, "root_key_id = ?", []interface{}{rootKeyId}, dbw.WithLimit(1), dbw.WithOrder("version desc")); err != nil {
+		return nil, fmt.Errorf("%s: failed for %q: %w", op, rootKeyId, err)
+	}
+	if len(foundKeys) == 0 {
+		return nil, fmt.Errorf("%s: %w", op, ErrRecordNotFound)
+	}
+	if err := foundKeys[0].Decrypt(ctx, keyWrapper); err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	return &foundKeys[0], nil
+}
+
+// ListRootKeyVersions in versions of a root key.  Supported options: WithLimit, WithOrderByVersion
+func (r *Repository) ListRootKeyVersions(ctx context.Context, keyWrapper wrapping.Wrapper, rootKeyId string, opt ...Option) ([]*RootKeyVersion, error) {
+	const op = "kms.(Repository).ListRootKeyVersions"
+	if rootKeyId == "" {
+		return nil, fmt.Errorf("%s: missing root key id: %w", op, ErrInvalidParameter)
+	}
+	if keyWrapper == nil {
+		return nil, fmt.Errorf("%s: missing key wrapper: %w", op, ErrInvalidParameter)
+	}
+	var versions []*RootKeyVersion
+	err := r.list(ctx, &versions, "root_key_id = ?", []interface{}{rootKeyId}, opt...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	for i, k := range versions {
+		if err := k.Decrypt(ctx, keyWrapper); err != nil {
+			return nil, fmt.Errorf("%s: error decrypting key num %d: %w", op, i, err)
+		}
+	}
+	return versions, nil
+}

--- a/extras/kms/repository_root_key_version_test.go
+++ b/extras/kms/repository_root_key_version_test.go
@@ -1,0 +1,526 @@
+package kms_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/hashicorp/go-dbw"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepository_CreateRootKeyVersion(t *testing.T) {
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+	rk := kms.TestRootKey(t, db, testScopeId)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		rootKeyId       string
+		key             []byte
+		keyWrapper      wrapping.Wrapper
+		opt             []kms.Option
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-root-key-id",
+			repo:            testRepo,
+			keyWrapper:      wrapper,
+			key:             []byte("test key"),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key id",
+		},
+		{
+			name:            "missing-wrapper",
+			repo:            testRepo,
+			rootKeyId:       rk.PrivateId,
+			key:             []byte("test key"),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name:            "missing-key",
+			repo:            testRepo,
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:            "bad-wrapper-fails-encrypt",
+			repo:            testRepo,
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      aead.NewWrapper(),
+			key:             []byte("test key"),
+			wantErr:         true,
+			wantErrContains: "unable to encrypt",
+		},
+		{
+			name: "create-rkv-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				testRepo, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`INSERT INTO "kms_root_key_version"`).WillReturnError(errors.New("create-rkv-error"))
+				mock.ExpectRollback()
+				return testRepo
+			}(),
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      wrapper,
+			key:             []byte("test key"),
+			wantErr:         true,
+			wantErrContains: "create-rkv-error",
+		},
+		{
+			name:       "valid",
+			repo:       testRepo,
+			rootKeyId:  rk.PrivateId,
+			keyWrapper: wrapper,
+			key:        []byte("test key"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			k, err := tc.repo.CreateRootKeyVersion(context.Background(), tc.keyWrapper, tc.rootKeyId, tc.key, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(k.CreateTime)
+			assert.Equal(uint32(1), k.Version)
+			foundKey, err := tc.repo.LookupRootKeyVersion(context.Background(), tc.keyWrapper, k.PrivateId)
+			assert.NoError(err)
+			assert.Equal(k, foundKey)
+		})
+	}
+}
+
+func TestRepository_DeleteRootKeyVersion(t *testing.T) {
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+	rk := kms.TestRootKey(t, db, testScopeId)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		key             *kms.RootKeyVersion
+		opt             []kms.Option
+		wantRowsDeleted int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "missing-private-id",
+			repo: testRepo,
+			key: func() *kms.RootKeyVersion {
+				return &kms.RootKeyVersion{}
+			}(),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "not-found",
+			repo: testRepo,
+			key: func() *kms.RootKeyVersion {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKeyVersion{}
+				k.PrivateId = id
+				return &k
+			}(),
+			wantErr:         true,
+			wantErrIs:       kms.ErrRecordNotFound,
+			wantErrContains: "record not found",
+		},
+		{
+			name: "lookup-by-error",
+			key: func() *kms.RootKeyVersion {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKeyVersion{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("lookup-by-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "lookup-by-error",
+		},
+		{
+			name: "delete-error",
+			key: func() *kms.RootKeyVersion {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKeyVersion{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnError(errors.New("delete-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrContains: "delete-error",
+		},
+		{
+			name: "delete-too-many-error",
+			key: func() *kms.RootKeyVersion {
+				id, err := dbw.NewId(kms.RootKeyPrefix)
+				require.NoError(t, err)
+				k := kms.RootKeyVersion{}
+				k.PrivateId = id
+				require.NoError(t, err)
+				return &k
+			}(),
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin()
+				mock.ExpectExec(`DELETE`).WillReturnResult(sqlmock.NewResult(0, 2))
+				mock.ExpectRollback()
+				return r
+			}(),
+			wantRowsDeleted: 0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrMultipleRecords,
+			wantErrContains: "multiple records",
+		},
+		{
+			name: "valid",
+			repo: testRepo,
+			key: func() *kms.RootKeyVersion {
+				k, _ := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+				return k
+			}(),
+			wantRowsDeleted: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			deletedRows, err := tc.repo.DeleteRootKeyVersion(context.Background(), tc.key.PrivateId, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantRowsDeleted, deletedRows)
+			foundKey, err := tc.repo.LookupRootKeyVersion(context.Background(), wrapper, tc.key.PrivateId)
+			assert.Error(err)
+			assert.Nil(foundKey)
+			assert.ErrorIs(err, kms.ErrRecordNotFound)
+		})
+	}
+}
+
+func TestRepository_LatestRootKeyVersion(t *testing.T) {
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw)
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+	rk := kms.TestRootKey(t, db, testScopeId)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		createCnt       int
+		rootKeyId       string
+		keyWrapper      wrapping.Wrapper
+		wantVersion     uint32
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:        "5",
+			repo:        testRepo,
+			createCnt:   5,
+			rootKeyId:   rk.PrivateId,
+			keyWrapper:  wrapper,
+			wantVersion: 5,
+		},
+		{
+			name:        "1",
+			repo:        testRepo,
+			createCnt:   1,
+			rootKeyId:   rk.PrivateId,
+			keyWrapper:  wrapper,
+			wantVersion: 1,
+		},
+		{
+			name:            "0",
+			repo:            testRepo,
+			createCnt:       0,
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrRecordNotFound,
+			wantErrContains: "record not found",
+		},
+		{
+			name:            "missing-root-key-id",
+			repo:            testRepo,
+			createCnt:       5,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key id",
+		},
+		{
+			name:            "nil-wrapper",
+			repo:            testRepo,
+			createCnt:       5,
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      nil,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name: "search-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("search-error"))
+				return r
+			}(),
+			createCnt:       5,
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrContains: "search-error",
+		},
+		{
+			name:            "bad-wrapper",
+			repo:            testRepo,
+			createCnt:       5,
+			rootKeyId:       rk.PrivateId,
+			keyWrapper:      aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "unable to decrypt",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.RootKeyVersion{}; return &i }(), "1=1")
+			testKeys := []*kms.RootKeyVersion{}
+			for i := 0; i < tc.createCnt; i++ {
+				k, _ := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+				testKeys = append(testKeys, k)
+			}
+			assert.Equal(tc.createCnt, len(testKeys))
+			got, err := tc.repo.LatestRootKeyVersion(context.Background(), tc.keyWrapper, tc.rootKeyId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			require.NotNil(got)
+			assert.Equal(tc.wantVersion, got.Version)
+		})
+	}
+}
+
+func TestRepository_ListRootKeyVersions(t *testing.T) {
+	const testLimit = 10
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+	testRepo, err := kms.NewRepository(rw, rw, kms.WithLimit(testLimit))
+	require.NoError(t, err)
+	testScopeId := "o_1234567890"
+	rk := kms.TestRootKey(t, db, testScopeId)
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		createCnt       int
+		rootKeyId       string
+		keyWrapper      wrapping.Wrapper
+		opt             []kms.Option
+		wantCnt         int
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:       "no-limit",
+			repo:       testRepo,
+			createCnt:  testLimit * 2,
+			rootKeyId:  rk.PrivateId,
+			keyWrapper: wrapper,
+			opt:        []kms.Option{kms.WithLimit(-1)},
+			wantCnt:    testLimit * 2,
+		},
+		{
+			name:       "default-limit",
+			repo:       testRepo,
+			createCnt:  testLimit + 1,
+			keyWrapper: wrapper,
+			rootKeyId:  rk.PrivateId,
+			wantCnt:    testLimit,
+			wantErr:    false,
+		},
+		{
+			name:       "custom-limit",
+			repo:       testRepo,
+			createCnt:  testLimit + 1,
+			keyWrapper: wrapper,
+			rootKeyId:  rk.PrivateId,
+			opt:        []kms.Option{kms.WithLimit(3)},
+			wantCnt:    3,
+			wantErr:    false,
+		},
+		{
+			name:            "bad-wrapper",
+			repo:            testRepo,
+			createCnt:       1,
+			keyWrapper:      aead.NewWrapper(),
+			rootKeyId:       rk.PrivateId,
+			wantErr:         true,
+			wantErrContains: "unable to decrypt",
+		},
+		{
+			name:            "missing-root-key-id",
+			repo:            testRepo,
+			createCnt:       1,
+			keyWrapper:      wrapper,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root key id",
+		},
+		{
+			name:            "missing-wrapper",
+			repo:            testRepo,
+			createCnt:       1,
+			keyWrapper:      nil,
+			rootKeyId:       rk.PrivateId,
+			wantCnt:         0,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing key wrapper",
+		},
+		{
+			name: "list-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("list-error"))
+				return r
+			}(),
+			keyWrapper:      wrapper,
+			rootKeyId:       rk.PrivateId,
+			createCnt:       testLimit,
+			wantErr:         true,
+			wantErrContains: "list-error",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.RootKeyVersion{}; return &i }(), "1=1")
+			testRootKeyVersions := []*kms.RootKeyVersion{}
+			for i := 0; i < tc.createCnt; i++ {
+				k, _ := kms.TestRootKeyVersion(t, db, wrapper, rk.PrivateId)
+				testRootKeyVersions = append(testRootKeyVersions, k)
+			}
+			assert.Equal(tc.createCnt, len(testRootKeyVersions))
+			got, err := tc.repo.ListRootKeyVersions(context.Background(), tc.keyWrapper, tc.rootKeyId, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantCnt, len(got))
+		})
+	}
+}

--- a/extras/kms/repository_test.go
+++ b/extras/kms/repository_test.go
@@ -351,7 +351,6 @@ func TestRepository_CreateKeysTx(t *testing.T) {
 			assert.NotNil(keys)
 		})
 	}
-
 }
 
 func TestRepository_DefaultLimit(t *testing.T) {

--- a/extras/kms/repository_test.go
+++ b/extras/kms/repository_test.go
@@ -2,13 +2,17 @@ package kms_test
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
+	"io"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/hashicorp/go-dbw"
 	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
 	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -60,6 +64,22 @@ func TestNewRepository(t *testing.T) {
 			wantErrIs:       kms.ErrInvalidParameter,
 			wantErrContains: "nil reader",
 		},
+		{
+			name: "valid",
+			args: args{
+				r: func() dbw.Reader {
+					db, mock := dbw.TestSetupWithMock(t)
+					rw := dbw.New(db)
+					mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow("invalid-version", time.Now()))
+					return rw
+				}(),
+				w: rw,
+			},
+			want:            kms.TestRepo(t, db),
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidVersion,
+			wantErrContains: "invalid schema version",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -102,6 +122,7 @@ func TestRepository_ValidateVersion(t *testing.T) {
 			repo: func() *kms.Repository {
 				mDb, mock := kms.TestMockDb(t)
 				rw := dbw.New(mDb)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
 				r, err := kms.NewRepository(rw, rw)
 				require.NoError(t, err)
 				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(100))
@@ -115,6 +136,7 @@ func TestRepository_ValidateVersion(t *testing.T) {
 			repo: func() *kms.Repository {
 				mDb, mock := kms.TestMockDb(t)
 				rw := dbw.New(mDb)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
 				r, err := kms.NewRepository(rw, rw)
 				require.NoError(t, err)
 				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("failed-lookup"))
@@ -142,4 +164,201 @@ func TestRepository_ValidateVersion(t *testing.T) {
 			assert.Equal(tc.wantVersion, version)
 		})
 	}
+}
+
+type mockRandReader struct {
+	readCnt   uint
+	errMsg    string
+	errOnRead uint
+}
+
+func newMockRandReader(errOnRead uint, errMsg string) *mockRandReader {
+	return &mockRandReader{
+		readCnt:   0,
+		errMsg:    errMsg,
+		errOnRead: errOnRead,
+	}
+}
+
+func (m *mockRandReader) Read(p []byte) (n int, err error) {
+	m.readCnt++
+	if m.readCnt < m.errOnRead {
+		return rand.Read(p)
+	}
+	return 0, errors.New(m.errMsg)
+}
+
+func TestRepository_CreateKeysTx(t *testing.T) {
+	const testScopeId = "o_1234567890"
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	testRepo, err := kms.NewRepository(rw, rw, kms.WithLimit(3))
+	require.NoError(t, err)
+	wrapper := wrapping.NewTestWrapper([]byte(kms.DefaultWrapperSecret))
+
+	tests := []struct {
+		name            string
+		repo            *kms.Repository
+		rootWrapper     wrapping.Wrapper
+		rand            io.Reader
+		scopeId         string
+		purpose         []kms.KeyPurpose
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-wrapper",
+			repo:            testRepo,
+			rand:            rand.Reader,
+			scopeId:         testScopeId,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing root wrapper",
+		},
+		{
+			name:            "missing-random-reader",
+			repo:            testRepo,
+			rootWrapper:     wrapper,
+			scopeId:         testScopeId,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing random reader",
+		},
+		{
+			name:            "missing-scope-id",
+			repo:            testRepo,
+			rootWrapper:     wrapper,
+			rand:            rand.Reader,
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing scope id",
+		},
+		{
+			name:            "reserved-purpose",
+			repo:            testRepo,
+			rootWrapper:     wrapper,
+			rand:            rand.Reader,
+			scopeId:         testScopeId,
+			purpose:         []kms.KeyPurpose{"rootKey", "database"},
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "reserved key purpose",
+		},
+		{
+			name:            "dup-purpose",
+			repo:            testRepo,
+			rootWrapper:     wrapper,
+			rand:            rand.Reader,
+			scopeId:         testScopeId,
+			purpose:         []kms.KeyPurpose{"database", "database"},
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "duplicate key purpose",
+		},
+		{
+			name:            "gen-root-key-error",
+			repo:            testRepo,
+			rootWrapper:     wrapper,
+			rand:            newMockRandReader(1, "gen-root-key-error"),
+			scopeId:         testScopeId,
+			purpose:         []kms.KeyPurpose{"database", "session"},
+			wantErr:         true,
+			wantErrContains: "gen-root-key-error",
+		},
+		{
+			name:            "gen-purpose-key-error",
+			repo:            testRepo,
+			rootWrapper:     wrapper,
+			rand:            newMockRandReader(2, "gen-purpose-key-error"),
+			scopeId:         testScopeId,
+			purpose:         []kms.KeyPurpose{"database", "session"},
+			wantErr:         true,
+			wantErrContains: "gen-purpose-key-error",
+		},
+		{
+			name: "createRootKeyTx-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin()
+				mock.ExpectQuery(`INSERT INTO "kms_root_key"`).WillReturnError(errors.New("createRootKeyTx-error"))
+				mock.ExpectRollback()
+				return r
+			}(),
+			rootWrapper:     wrapper,
+			rand:            rand.Reader,
+			scopeId:         testScopeId,
+			purpose:         []kms.KeyPurpose{"database", "session"},
+			wantErr:         true,
+			wantErrContains: "createRootKeyTx-error",
+		},
+		{
+			name: "createDataKeyTx-error",
+			repo: func() *kms.Repository {
+				db, mock := dbw.TestSetupWithMock(t)
+				rw := dbw.New(db)
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"version", "create_time"}).AddRow(migrations.Version, time.Now()))
+				r, err := kms.NewRepository(rw, rw)
+				require.NoError(t, err)
+				mock.ExpectBegin() // rk
+				mock.ExpectQuery(`INSERT INTO`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectCommit()
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectBegin() // rkv
+				mock.ExpectQuery(`INSERT INTO`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectCommit()
+				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
+				mock.ExpectQuery(`SELECT`).WillReturnError(errors.New("createDataKeyTx-error"))
+				return r
+			}(),
+			rootWrapper:     wrapper,
+			rand:            rand.Reader,
+			scopeId:         testScopeId,
+			purpose:         []kms.KeyPurpose{"database", "session"},
+			wantErr:         true,
+			wantErrContains: "createDataKeyTx-error",
+		},
+		{
+			name:        "success",
+			repo:        testRepo,
+			rootWrapper: wrapper,
+			rand:        rand.Reader,
+			scopeId:     testScopeId,
+			purpose:     []kms.KeyPurpose{"database", "session"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			kms.TestDeleteWhere(t, db, func() interface{} { i := kms.RootKey{}; return &i }(), "1=1")
+			keys, err := tc.repo.CreateKeysTx(context.Background(), tc.rootWrapper, tc.rand, tc.scopeId, tc.purpose...)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotNil(keys)
+		})
+	}
+
+}
+
+func TestRepository_DefaultLimit(t *testing.T) {
+	t.Parallel()
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	testRepo, err := kms.NewRepository(rw, rw, kms.WithLimit(3))
+	require.NoError(t, err)
+	assert.Equal(t, 3, testRepo.DefaultLimit())
 }

--- a/extras/kms/root_key.go
+++ b/extras/kms/root_key.go
@@ -38,3 +38,6 @@ func (k *RootKey) Clone() *RootKey {
 		CreateTime: k.CreateTime,
 	}
 }
+
+// GetPrivateId returns the key's private id
+func (k *RootKey) GetPrivateId() string { return k.PrivateId }

--- a/extras/kms/root_key_test.go
+++ b/extras/kms/root_key_test.go
@@ -1,0 +1,53 @@
+package kms_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewRootKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		scopeId         string
+		want            *kms.RootKey
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-scope-id",
+			wantErr:         true,
+			wantErrIs:       kms.ErrInvalidParameter,
+			wantErrContains: "missing scope id",
+		},
+		{
+			name:    "success",
+			scopeId: "scope-id",
+			want: &kms.RootKey{
+				ScopeId: "scope-id",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := kms.NewRootKey(tc.scopeId)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.want, got)
+		})
+	}
+}

--- a/extras/kms/root_key_version.go
+++ b/extras/kms/root_key_version.go
@@ -66,7 +66,7 @@ func (k *RootKeyVersion) Clone() *RootKeyVersion {
 }
 
 // VetForWrite validates the root key version before it's written.
-func (k *RootKeyVersion) vetForWrite(ctx context.Context, _ dbw.Reader, opType dbw.OpType) error {
+func (k *RootKeyVersion) vetForWrite(ctx context.Context, opType dbw.OpType) error {
 	const op = "kms.(RootKeyVersion).VetForWrite"
 	if k.PrivateId == "" {
 		return fmt.Errorf("%s: missing private id: %w", op, ErrInvalidParameter)
@@ -88,6 +88,9 @@ func (k *RootKeyVersion) vetForWrite(ctx context.Context, _ dbw.Reader, opType d
 // Encrypt will encrypt the root key version's key
 func (k *RootKeyVersion) Encrypt(ctx context.Context, cipher wrapping.Wrapper) error {
 	const op = "kms.(RootKeyVersion).Encrypt"
+	if cipher == nil {
+		return fmt.Errorf("%s: missing cipher: %w", op, ErrInvalidParameter)
+	}
 	if err := structwrapping.WrapStruct(ctx, cipher, k, nil); err != nil {
 		return fmt.Errorf("%s: unable to encrypt: %w", op, err)
 	}
@@ -97,8 +100,14 @@ func (k *RootKeyVersion) Encrypt(ctx context.Context, cipher wrapping.Wrapper) e
 // Decrypt will decrypt the root key version's key
 func (k *RootKeyVersion) Decrypt(ctx context.Context, cipher wrapping.Wrapper) error {
 	const op = "kms.(RootKeyVersion).Decrypt"
+	if cipher == nil {
+		return fmt.Errorf("%s: missing cipher: %w", op, ErrInvalidParameter)
+	}
 	if err := structwrapping.UnwrapStruct(ctx, cipher, k, nil); err != nil {
 		return fmt.Errorf("%s: unable to decrypt: %w", op, err)
 	}
 	return nil
 }
+
+// GetPrivateId returns the key's private id
+func (k *RootKeyVersion) GetPrivateId() string { return k.PrivateId }

--- a/extras/kms/root_key_version_test.go
+++ b/extras/kms/root_key_version_test.go
@@ -1,0 +1,268 @@
+package kms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_NewRootKeyVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		rootKeyId       string
+		key             []byte
+		want            *RootKeyVersion
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "missing-root-key-id",
+			key:             []byte("key"),
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing root key id",
+		},
+		{
+			name:            "missing-key",
+			rootKeyId:       "root-key-id",
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name:      "valid",
+			rootKeyId: "root-key-id",
+			key:       []byte("key"),
+			want: &RootKeyVersion{
+				RootKeyId: "root-key-id",
+				Key:       []byte("key"),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			got, err := NewRootKeyVersion(tc.rootKeyId, tc.key)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestRootKeyVersion_vetForWrite(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	tests := []struct {
+		name            string
+		key             *RootKeyVersion
+		opType          dbw.OpType
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "create-missing-private-id",
+			key: &RootKeyVersion{
+				RootKeyId: "root-key-id",
+				CtKey:     []byte("key"),
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing private id",
+		},
+		{
+			name: "create-missing-ct-key",
+			key: &RootKeyVersion{
+				PrivateId: "private-id",
+				RootKeyId: "root-key-id",
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing key",
+		},
+		{
+			name: "create-missing-root-key-id",
+			key: &RootKeyVersion{
+				PrivateId: "private-id",
+				CtKey:     []byte("key"),
+			},
+			opType:          dbw.CreateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "missing root key id",
+		},
+		{
+			name: "update-immutable",
+			key: &RootKeyVersion{
+				PrivateId: "private-id",
+			},
+			opType:          dbw.UpdateOp,
+			wantErr:         true,
+			wantErrIs:       ErrInvalidParameter,
+			wantErrContains: "key is immutable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			err := tc.key.vetForWrite(testCtx, tc.opType)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+		})
+	}
+}
+
+func TestRootKeyVersion_Encrypt(t *testing.T) {
+	t.Parallel()
+	const (
+		testKey = "test-key"
+	)
+	testCtx := context.Background()
+	testWrapper := wrapping.NewTestWrapper([]byte(DefaultWrapperSecret))
+	tests := []struct {
+		name            string
+		key             *RootKeyVersion
+		wrapper         wrapping.Wrapper
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "bad-cipher",
+			key: &RootKeyVersion{
+				Key: []byte(testKey),
+			},
+			wrapper:         aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "error wrapping value",
+		},
+		{
+			name: "missing-cipher",
+			key: &RootKeyVersion{
+				Key: []byte(testKey),
+			},
+			wantErr:         true,
+			wantErrContains: "missing cipher",
+		},
+		{
+			name: "success",
+			key: &RootKeyVersion{
+				Key: []byte(testKey),
+			},
+			wrapper: testWrapper,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			require.Empty(tc.key.CtKey)
+			require.NotEmpty(tc.key.Key)
+			err := tc.key.Encrypt(testCtx, tc.wrapper)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.NotEmpty(tc.key.CtKey)
+			tc.key.Key = nil
+			err = tc.key.Decrypt(testCtx, tc.wrapper)
+			require.NoError(err)
+			assert.Equal(testKey, string(tc.key.Key))
+		})
+	}
+}
+
+func TestRootKeyVersion_Decrypt(t *testing.T) {
+	t.Parallel()
+	const (
+		testKey = "test-key"
+	)
+	testCtx := context.Background()
+	testWrapper := wrapping.NewTestWrapper([]byte(DefaultWrapperSecret))
+	testDataKey := &RootKeyVersion{
+		Key: []byte(testKey),
+	}
+	err := testDataKey.Encrypt(testCtx, testWrapper)
+	require.NoError(t, err)
+	tests := []struct {
+		name            string
+		key             *RootKeyVersion
+		wrapper         wrapping.Wrapper
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name:            "bad-cipher",
+			key:             testDataKey,
+			wrapper:         aead.NewWrapper(),
+			wantErr:         true,
+			wantErrContains: "error unwrapping value",
+		},
+		{
+			name:            "missing-cipher",
+			key:             testDataKey,
+			wantErr:         true,
+			wantErrContains: "missing cipher",
+		},
+		{
+			name:    "success",
+			key:     testDataKey,
+			wrapper: testWrapper,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			require.NotEmpty(tc.key.CtKey)
+			require.NotEmpty(tc.key.Key)
+			err := tc.key.Decrypt(testCtx, tc.wrapper)
+			if tc.wantErr {
+				require.Error(err)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(testKey, string(tc.key.Key))
+		})
+	}
+}

--- a/extras/kms/schema_test.go
+++ b/extras/kms/schema_test.go
@@ -397,7 +397,6 @@ func TestDataKey_Version(t *testing.T) {
 		require.NoError(rw.LookupBy(testCtx, found))
 		found.Decrypt(testCtx, wrapper)
 		assert.Equal(dkv3, found)
-
 	})
 	t.Run("test-dup-purpose", func(t *testing.T) {
 		const testPurpose = "test"

--- a/extras/kms/schema_test.go
+++ b/extras/kms/schema_test.go
@@ -2,6 +2,7 @@ package kms_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +12,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRootKey_ScopeId(t *testing.T) {
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+	db, _ := kms.TestDb(t)
+	rw := dbw.New(db)
+	testScopeId := "o_1234567890"
+	_ = kms.TestRootKey(t, db, testScopeId)
+
+	k, err := kms.NewRootKey(testScopeId)
+	require.NoError(err)
+	id, err := dbw.NewId(kms.RootKeyPrefix)
+	require.NoError(err)
+	k.PrivateId = id
+	err = rw.Create(context.Background(), k)
+	assert.Error(err)
+	assert.Contains(strings.ToLower(err.Error()), "unique")
+}
 
 func TestRootKeyVersion_ImmutableFields(t *testing.T) {
 	t.Parallel()

--- a/extras/kms/testing.go
+++ b/extras/kms/testing.go
@@ -34,7 +34,7 @@ func TestRootKey(t *testing.T, conn *dbw.DB, scopeId string) *RootKey {
 	id, err := newRootKeyId()
 	require.NoError(err)
 	k.PrivateId = id
-	err = rw.Create(context.Background(), k)
+	err = create(context.Background(), rw, k)
 	require.NoError(err)
 	return k
 }
@@ -55,7 +55,7 @@ func TestRootKeyVersion(t *testing.T, conn *dbw.DB, wrapper wrapping.Wrapper, ro
 	k.PrivateId = id
 	err = k.Encrypt(context.Background(), wrapper)
 	require.NoError(err)
-	err = rw.Create(context.Background(), k)
+	err = create(context.Background(), rw, k)
 	require.NoError(err)
 	err = rw.LookupBy(context.Background(), k)
 	require.NoError(err)
@@ -65,7 +65,7 @@ func TestRootKeyVersion(t *testing.T, conn *dbw.DB, wrapper wrapping.Wrapper, ro
 }
 
 // TestData returns a new test DataKey
-func TestDataKey(t *testing.T, conn *dbw.DB, rootKeyId, purpose string) *DataKey {
+func TestDataKey(t *testing.T, conn *dbw.DB, rootKeyId string, purpose KeyPurpose) *DataKey {
 	t.Helper()
 	require := require.New(t)
 	TestDeleteWhere(t, conn, &DataKey{}, "root_key_id = ?", rootKeyId)
@@ -76,7 +76,7 @@ func TestDataKey(t *testing.T, conn *dbw.DB, rootKeyId, purpose string) *DataKey
 	require.NoError(err)
 	k.PrivateId = id
 	k.RootKeyId = rootKeyId
-	err = rw.Create(context.Background(), k)
+	err = create(context.Background(), rw, k)
 	require.NoError(err)
 	return k
 }
@@ -96,7 +96,7 @@ func TestDataKeyVersion(t *testing.T, conn *dbw.DB, rootKeyVersionWrapper wrappi
 	k.PrivateId = id
 	err = k.Encrypt(context.Background(), rootKeyVersionWrapper)
 	require.NoError(err)
-	err = rw.Create(context.Background(), k)
+	err = create(context.Background(), rw, k)
 	require.NoError(err)
 	err = rw.LookupBy(context.Background(), k)
 	require.NoError(err)


### PR DESCRIPTION
This PR adds the repository layer to the extras/kms module. It also adds models for DataKey and DataKeyVersion types and an additional schema test for duplicate scope ids.

Reviewers: once again the feature commits in this PR are based on work within Boundary's kms repository for reference. 