### PR TITLE
refactor (extras/kms): remove withRepository(...) option

### DIFF
--- a/extras/kms/option.go
+++ b/extras/kms/option.go
@@ -21,7 +21,6 @@ type Option func(*options)
 // options = how options are represented
 type options struct {
 	withLimit          int
-	withRepository     *repository
 	withKeyId          string
 	withOrderByVersion orderBy
 	withRetryCnt       uint
@@ -50,14 +49,6 @@ func getDefaultOptions() options {
 func withLimit(limit int) Option {
 	return func(o *options) {
 		o.withLimit = limit
-	}
-}
-
-// withRepository sets a repository for a given wrapper lookup, useful if in the
-// middle of a transaction where the reader/writer need to be specified
-func withRepository(repo *repository) Option {
-	return func(o *options) {
-		o.withRepository = repo
 	}
 }
 

--- a/extras/kms/option_test.go
+++ b/extras/kms/option_test.go
@@ -35,18 +35,6 @@ func Test_GetOpts(t *testing.T) {
 		opts.withErrorsMatching = nil
 		assert.Equal(opts, testOpts)
 	})
-	t.Run("WithRepository", func(t *testing.T) {
-		assert := assert.New(t)
-		db, _ := TestDb(t)
-		testRepo := testRepo(t, db)
-
-		opts := getOpts(withRepository(testRepo))
-		testOpts := getDefaultOptions()
-		testOpts.withRepository = testRepo
-		testOpts.withErrorsMatching = nil
-		opts.withErrorsMatching = nil
-		assert.Equal(opts, testOpts)
-	})
 	t.Run("WithKeyId", func(t *testing.T) {
 		assert := assert.New(t)
 		opts := getOpts(WithKeyId("id"))


### PR DESCRIPTION
It wasn't reachable from external callers anywho, and if you need
a specific reader/writer when using GetWrapper(...) then you just
need to create a new Kms with whatever reader/writer is needed.