### PR TITLE
feature (extras/kms): add TestDeleteKeyPurpose, TestKmsDeleteAllKeys

### DIFF
--- a/extras/kms/testing.go
+++ b/extras/kms/testing.go
@@ -116,6 +116,16 @@ func TestDb(t *testing.T) (*dbw.DB, string) {
 	return dbw.TestSetup(t, dbw.WithTestMigrationUsingDB(testMigrationFn(t)))
 }
 
+// TestDeleteKeyPurpose allows you to delete a KeyPurpose for testing.
+func TestDeleteKeyPurpose(t *testing.T, conn *dbw.DB, purpose KeyPurpose) {
+	testDeleteWhere(t, conn, func() interface{} { i := dataKey{}; return &i }(), fmt.Sprintf("purpose='%s'", purpose))
+}
+
+// TestKmsDeleteAllKeys allows you to delete ALL the keys for testing.
+func TestKmsDeleteAllKeys(t *testing.T, conn *dbw.DB) {
+	testDeleteWhere(t, conn, func() interface{} { i := rootKey{}; return &i }(), "1=1")
+}
+
 func testMigrationFn(t *testing.T) func(ctx context.Context, db *sql.DB) error {
 	return func(ctx context.Context, db *sql.DB) error {
 		t.Helper()

--- a/extras/kms/testing.go
+++ b/extras/kms/testing.go
@@ -116,8 +116,8 @@ func TestDb(t *testing.T) (*dbw.DB, string) {
 	return dbw.TestSetup(t, dbw.WithTestMigrationUsingDB(testMigrationFn(t)))
 }
 
-// TestDeleteKeyPurpose allows you to delete a KeyPurpose for testing.
-func TestDeleteKeyPurpose(t *testing.T, conn *dbw.DB, purpose KeyPurpose) {
+// TestDeleteKeysForPurpose allows you to delete all the keys for a KeyPurpose for testing.
+func TestDeleteKeysForPurpose(t *testing.T, conn *dbw.DB, purpose KeyPurpose) {
 	testDeleteWhere(t, conn, func() interface{} { i := dataKey{}; return &i }(), fmt.Sprintf("purpose='%s'", purpose))
 }
 

--- a/extras/kms/testing_test.go
+++ b/extras/kms/testing_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-dbw"
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,4 +17,59 @@ func Test_stub(t *testing.T) {
 	rows, err := rw.Query(context.Background(), "select * from kms_root_key", nil)
 	t.Log("rows: ", rows)
 	require.NoError(t, err)
+}
+
+func Test_TestDeleteKeyPurpose_TestDeleteAllKeys(t *testing.T) {
+	const (
+		globalScope = "global"
+		orgScope    = "o_1234567890"
+	)
+	t.Parallel()
+	assert, require := assert.New(t), require.New(t)
+	ctx := context.Background()
+	db, _ := TestDb(t)
+	rw := dbw.New(db)
+	extWrapper := wrapping.NewTestWrapper([]byte(testDefaultWrapperSecret))
+
+	databaseKeyPurpose := KeyPurpose("database")
+
+	// init kms with a cache
+	kmsCache, err := New(rw, rw, []KeyPurpose{"database"})
+	require.NoError(err)
+	require.NoError(kmsCache.AddExternalWrapper(ctx, KeyPurposeRootKey, extWrapper))
+	// Make the global scope base keys
+	err = kmsCache.CreateKeys(ctx, globalScope, []KeyPurpose{databaseKeyPurpose})
+	require.NoError(err)
+
+	_, err = kmsCache.GetWrapper(ctx, globalScope, databaseKeyPurpose)
+	require.NoError(err)
+
+	TestDeleteKeyPurpose(t, db, databaseKeyPurpose)
+
+	_, err = kmsCache.GetWrapper(ctx, globalScope, databaseKeyPurpose)
+	require.Error(err)
+	assert.ErrorIs(err, ErrKeyNotFound)
+
+	err = kmsCache.ReconcileKeys(ctx, []string{globalScope}, []KeyPurpose{databaseKeyPurpose})
+	require.NoError(err)
+
+	_, err = kmsCache.GetWrapper(ctx, globalScope, databaseKeyPurpose)
+	require.NoError(err)
+
+	err = kmsCache.CreateKeys(ctx, orgScope, []KeyPurpose{databaseKeyPurpose})
+	require.NoError(err)
+
+	TestKmsDeleteAllKeys(t, db)
+
+	_, err = kmsCache.GetWrapper(ctx, globalScope, databaseKeyPurpose)
+	require.Error(err)
+	assert.ErrorIs(err, ErrKeyNotFound)
+
+	_, err = kmsCache.GetWrapper(ctx, orgScope, databaseKeyPurpose)
+	require.Error(err)
+	assert.ErrorIs(err, ErrKeyNotFound)
+
+	_, err = kmsCache.GetWrapper(ctx, globalScope, KeyPurposeRootKey)
+	require.Error(err)
+	assert.ErrorIs(err, ErrKeyNotFound)
 }


### PR DESCRIPTION
These two new test functions allow callers to either delete a specific
key purpose or all the keys for testing.