### PR TITLE
extras/kms package: schema changes

### DIFF
--- a/extras/kms/CHANGELOG.md
+++ b/extras/kms/CHANGELOG.md
@@ -1,0 +1,16 @@
+# kms package CHANGELOG
+
+Canonical reference for changes, improvements, and bugfixes for the kms package.
+
+## Bug fixes
+* Explicitly naming FK and unique constraints so they can be referenced by name
+  in the future if any changes are required. Add the `kms` prefix to the
+  `update_time_column()` function. 
+  ([PR](https://github.com/hashicorp/go-kms-wrapping/pull/88)).
+
+  The decision was made to make these changes by modifying existing migrations,
+  so if you've already installed this package, you'll need to review the PR and
+  make the changes by hand in a new migration.
+
+
+

--- a/extras/kms/migrations/postgres/01_domain_types.up.sql
+++ b/extras/kms/migrations/postgres/01_domain_types.up.sql
@@ -5,11 +5,15 @@ not null
 check(
   length(trim(value)) > 0
 );
+comment on domain kms_private_id is
+'standard column for private id';
 
 create domain kms_scope_id as text
 check(
   length(trim(value)) > 0
 );
+comment on domain kms_scope_id is
+'standard column for scope id';
 
 create domain kms_timestamp as
   timestamp with time zone

--- a/extras/kms/migrations/postgres/01_domain_types.up.sql
+++ b/extras/kms/migrations/postgres/01_domain_types.up.sql
@@ -78,7 +78,7 @@ is
   'function used to properly set create_time columns';
 
 create or replace function
-  update_time_column()
+  kms_update_time_column()
   returns trigger
 as $$
 begin
@@ -91,7 +91,7 @@ begin
 end;
 $$ language plpgsql;
 comment on function
-  update_time_column()
+  kms_update_time_column()
 is
   'function used in before update triggers to properly set update_time columns';
 

--- a/extras/kms/migrations/postgres/02_version.up.sql
+++ b/extras/kms/migrations/postgres/02_version.up.sql
@@ -21,10 +21,10 @@ before
 insert on kms_schema_version
   for each row execute procedure kms_default_create_time();
 
-create trigger update_time_column 
+create trigger kms_update_time_column 
 before 
 update on kms_schema_version 
-	for each row execute procedure update_time_column();
+	for each row execute procedure kms_update_time_column();
 
 insert into kms_schema_version(version) values('v0.0.1');
 

--- a/extras/kms/migrations/postgres/04_keys.up.sql
+++ b/extras/kms/migrations/postgres/04_keys.up.sql
@@ -22,9 +22,10 @@ insert on kms_root_key
 create table kms_root_key_version (
   private_id kms_private_id primary key,
   root_key_id kms_private_id not null
-    references kms_root_key(private_id) 
-    on delete cascade 
-    on update cascade,
+    constraint kms_root_key_version_kms_root_key_fkey
+      references kms_root_key(private_id) 
+      on delete cascade 
+      on update cascade,
   version kms_version,
   key bytea not null
     constraint not_empty_key
@@ -32,7 +33,8 @@ create table kms_root_key_version (
       length(key) > 0
     ),
   create_time kms_timestamp,
-  unique(root_key_id, version)
+  constraint kms_root_key_version_root_key_id_version_uq
+    unique(root_key_id, version)
 );
 comment on table kms_root_key_version is
   'kms_root_key_version contains versions of a kms_root_key';
@@ -57,14 +59,16 @@ before insert on kms_root_key_version
 create table kms_data_key (
   private_id kms_private_id primary key,
   root_key_id kms_private_id not null
-    references kms_root_key(private_id)
-    on delete cascade
-    on update cascade,
+    constraint kms_data_key_kms_root_key_fkey
+      references kms_root_key(private_id)
+      on delete cascade
+      on update cascade,
   purpose text not null
     constraint not_start_end_whitespace_purpose
     check (length(trim(purpose)) = length(purpose)),
   create_time kms_timestamp,
-  unique (root_key_id, purpose) -- there can only be one dek for a specific purpose per root key
+  constraint kms_data_key_root_key_id_purpose_uq
+    unique (root_key_id, purpose) -- there can only be one dek for a specific purpose per root key
 );
 comment on table kms_data_key is
   'kms_data_key contains deks (data keys) for specific purposes';
@@ -83,13 +87,15 @@ insert on kms_data_key
 create table kms_data_key_version (
   private_id kms_private_id primary key,
   data_key_id kms_private_id not null
-    references kms_data_key(private_id) 
-    on delete cascade 
-    on update cascade, 
+    constraint kms_data_key_version_kms_data_key_fkey
+      references kms_data_key(private_id) 
+      on delete cascade 
+      on update cascade, 
   root_key_version_id kms_private_id not null
-    references kms_root_key_version(private_id) 
-    on delete cascade 
-    on update cascade,
+    constraint kms_data_key_version_kms_root_key_version_fkey
+      references kms_root_key_version(private_id) 
+      on delete cascade 
+      on update cascade,
   version kms_version,
   key bytea not null
     constraint not_empty_key
@@ -97,7 +103,8 @@ create table kms_data_key_version (
       length(key) > 0
     ),
   create_time kms_timestamp,
-  unique(data_key_id, version)
+  constraint kms_data_key_version_data_key_id_version_uq
+    unique(data_key_id, version)
 );
 comment on table kms_data_key is
   'kms_data_key_version contains versions of a kms_data_key (dek aka data keys)';

--- a/extras/kms/migrations/postgres/04_keys.up.sql
+++ b/extras/kms/migrations/postgres/04_keys.up.sql
@@ -22,7 +22,7 @@ insert on kms_root_key
 create table kms_root_key_version (
   private_id kms_private_id primary key,
   root_key_id kms_private_id not null
-    constraint kms_root_key_version_kms_root_key_fkey
+    constraint kms_root_key_fkey
       references kms_root_key(private_id) 
       on delete cascade 
       on update cascade,
@@ -59,7 +59,7 @@ before insert on kms_root_key_version
 create table kms_data_key (
   private_id kms_private_id primary key,
   root_key_id kms_private_id not null
-    constraint kms_data_key_kms_root_key_fkey
+    constraint kms_root_key_fkey
       references kms_root_key(private_id)
       on delete cascade
       on update cascade,
@@ -87,12 +87,12 @@ insert on kms_data_key
 create table kms_data_key_version (
   private_id kms_private_id primary key,
   data_key_id kms_private_id not null
-    constraint kms_data_key_version_kms_data_key_fkey
+    constraint kms_data_key_fkey
       references kms_data_key(private_id) 
       on delete cascade 
       on update cascade, 
   root_key_version_id kms_private_id not null
-    constraint kms_data_key_version_kms_root_key_version_fkey
+    constraint kms_root_key_version_fkey
       references kms_root_key_version(private_id) 
       on delete cascade 
       on update cascade,


### PR DESCRIPTION
This PR includes a few minor changes and a few critical schema changes.   

The critical schema changes involve:

- Explicitly naming FK and unique constraints so they can be referenced by name in the future if any changes are required.  
- Adding the `kms` prefix to the `update_time_column()` function

The minor changes were just some additional comments to existing tables.