### PR TITLE
refactor (extras/kms): add version to the entire kms collection and always enable the cache

### DIFF
--- a/extras/kms/go.mod
+++ b/extras/kms/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/stretchr/testify v1.7.0
+	google.golang.org/protobuf v1.27.1
 	mvdan.cc/gofumpt v0.3.0
 )
 
@@ -45,7 +46,6 @@ require (
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
-	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	gorm.io/driver/postgres v1.2.2 // indirect
 	gorm.io/driver/sqlite v1.2.4 // indirect

--- a/extras/kms/go.sum
+++ b/extras/kms/go.sum
@@ -559,10 +559,6 @@ github.com/hashicorp/go-dbw v0.0.0-20220412153211-c470aec9369f/go.mod h1:w9gD0GS
 github.com/hashicorp/go-hclog v1.0.0 h1:bkKf0BeBXcSYa7f5Fyi9gMuQ8gNsxeiNpZjR6VxNZeo=
 github.com/hashicorp/go-hclog v1.0.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.5-0.20220321175502-0989a9b6deb1 h1:UFHzbA/voyzrVfxvm83LW6Hq2gd43F0mgchFnqrinjA=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.5-0.20220321175502-0989a9b6deb1/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.5 h1:rOFDv+3k05mnW0oaDLffhVUwg03Csn0mvfO98Wdd2bE=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.5/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20220602193636-404007edfc2b h1:L4ifQ7wEer0MSUr08JTepF8TJEBRexOF7jsv3H9jXZE=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.6-0.20220602193636-404007edfc2b/go.mod h1:sDQAfwJGv25uGPZA04x87ERglCG6avnRcBT9wYoMII8=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=

--- a/extras/kms/kms.go
+++ b/extras/kms/kms.go
@@ -200,7 +200,7 @@ func (k *Kms) GetWrapper(ctx context.Context, scopeId string, purpose KeyPurpose
 		return nil, fmt.Errorf("%s: unable to determine current version of the kms collection: %w", op, err)
 	}
 	switch {
-	case currVersion > atomic.LoadUint64(&k.collectionVersion):
+	case currVersion != atomic.LoadUint64(&k.collectionVersion):
 		k.clearCache(ctx)
 		atomic.StoreUint64(&k.collectionVersion, currVersion)
 	default:

--- a/extras/kms/kms.go
+++ b/extras/kms/kms.go
@@ -291,6 +291,10 @@ func (k *Kms) CreateKeys(ctx context.Context, scopeId string, purposes []KeyPurp
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
+	if err := updateKeyCollectionVersion(ctx, w); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
 	opts := getOpts(opt...)
 	if _, err := createKeysTx(ctx, r, w, rootWrapper, opts.withRandomReader, scopeId, purposes...); err != nil {
 		if localTx != nil {
@@ -384,6 +388,10 @@ func (k *Kms) RotateKeys(ctx context.Context, scopeId string, opt ...Option) err
 		return fmt.Errorf("%s: %w", op, err)
 	}
 
+	if err := updateKeyCollectionVersion(ctx, writer); err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
 	// since we could have started a local txn, we'll use an anon function for
 	// all the stmts which should be managed within that possible local txn.
 	if err := func() error {
@@ -471,6 +479,10 @@ func (k *Kms) RewrapKeys(ctx context.Context, scopeId string, opt ...Option) err
 
 	reader, writer, localTx, err := k.txFromOpts(ctx, opt...)
 	if err != nil {
+		return fmt.Errorf("%s: %w", op, err)
+	}
+
+	if err := updateKeyCollectionVersion(ctx, writer); err != nil {
 		return fmt.Errorf("%s: %w", op, err)
 	}
 

--- a/extras/kms/kms_test.go
+++ b/extras/kms/kms_test.go
@@ -857,15 +857,16 @@ func TestKms_ReconcileKeys(t *testing.T) {
 	)
 
 	tests := []struct {
-		name            string
-		kms             *kms.Kms
-		scopeIds        []string
-		opt             []kms.Option
-		setup           func(*kms.Kms)
-		wantPurpose     []kms.KeyPurpose
-		wantErr         bool
-		wantErrIs       error
-		wantErrContains string
+		name               string
+		kms                *kms.Kms
+		scopeIds           []string
+		opt                []kms.Option
+		setup              func(*kms.Kms)
+		wantPurpose        []kms.KeyPurpose
+		wantUpdatedVersion bool
+		wantErr            bool
+		wantErrIs          error
+		wantErrContains    string
 	}{
 		{
 			name: "missing-scope-ids",
@@ -974,8 +975,9 @@ func TestKms_ReconcileKeys(t *testing.T) {
 				_, err = k.GetWrapper(testCtx, org, "database")
 				require.Error(t, err)
 			},
-			scopeIds:    []string{"global"},
-			wantPurpose: []kms.KeyPurpose{"database"},
+			scopeIds:           []string{"global"},
+			wantPurpose:        []kms.KeyPurpose{"database"},
+			wantUpdatedVersion: true,
 		},
 		{
 			name: "success-rand-reader-option",
@@ -999,8 +1001,9 @@ func TestKms_ReconcileKeys(t *testing.T) {
 				_, err = k.GetWrapper(testCtx, org, "database")
 				require.Error(t, err)
 			},
-			scopeIds:    []string{org},
-			wantPurpose: []kms.KeyPurpose{"database"},
+			scopeIds:           []string{org},
+			wantPurpose:        []kms.KeyPurpose{"database"},
+			wantUpdatedVersion: true,
 		},
 		{
 			name: "nothing-to-reconcile",
@@ -1047,9 +1050,10 @@ func TestKms_ReconcileKeys(t *testing.T) {
 				_, err = k.GetWrapper(testCtx, org, "database")
 				require.Error(t, err)
 			},
-			scopeIds:    []string{org},
-			wantPurpose: []kms.KeyPurpose{"database"},
-			wantErr:     false,
+			scopeIds:           []string{org},
+			wantPurpose:        []kms.KeyPurpose{"database"},
+			wantErr:            false,
+			wantUpdatedVersion: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1083,7 +1087,7 @@ func TestKms_ReconcileKeys(t *testing.T) {
 				}
 			}
 
-			if tt.name != "nothing-to-reconcile" {
+			if tt.wantUpdatedVersion {
 				currVersion, err := currentCollectionVersion(testCtx, rw)
 				require.NoError(err)
 				assert.Greater(currVersion, prevVersion)

--- a/extras/kms/migrations/fs.go
+++ b/extras/kms/migrations/fs.go
@@ -3,7 +3,7 @@ package migrations
 import "embed"
 
 // Version defines the current migrations version required by the module
-const Version = "v0.0.1"
+const Version = "v0.0.2"
 
 // PostgresFS contains the sql for creating the postgres tables
 //go:embed postgres

--- a/extras/kms/migrations/postgres/06_kms_collection_version.up.sql
+++ b/extras/kms/migrations/postgres/06_kms_collection_version.up.sql
@@ -1,0 +1,28 @@
+begin;
+
+create table kms_collection_version (
+    version kms_version,
+    create_time timestamp not null default current_timestamp,
+    update_time timestamp not null default current_timestamp
+);
+
+-- ensure that it's only ever one row
+create unique index kms_collection_version_one_row
+ON kms_collection_version((version is not null));
+
+create trigger kms_immutable_columns
+before
+update on kms_collection_version
+  for each row execute procedure kms_immutable_columns('create_time');
+
+create trigger kms_update_time_column 
+before 
+update on kms_collection_version 
+	for each row execute procedure kms_update_time_column();
+
+
+insert into kms_collection_version(version) values(1);
+
+update kms_schema_version set version = 'v0.0.2';
+
+commit;

--- a/extras/kms/migrations/sqlite/06_kms_collection_version.up.sql
+++ b/extras/kms/migrations/sqlite/06_kms_collection_version.up.sql
@@ -1,0 +1,35 @@
+create table kms_collection_version (
+    version int not null,
+    create_time timestamp not null default current_timestamp,
+    update_time timestamp not null default current_timestamp
+);
+
+-- ensure that it's only ever one row
+create unique index kms_collection_version_one_row
+ON kms_collection_version((version is not null));
+
+create trigger kms_immutable_columns_kms_collection_version
+before update on kms_collection_version
+for each row 
+  when 
+    new.create_time <> old.create_time 
+	begin
+	  select raise(abort, 'immutable column');
+	end;
+
+
+create trigger update_time_column_kms_collection_version
+before update on kms_collection_version
+for each row 
+when 
+  new.version <> old.version 
+  begin
+    update kms_collection_version set update_time = datetime('now','localtime') where rowid == new.rowid;
+  end;
+
+
+insert into kms_collection_version(version) values(1);
+
+update kms_schema_version set version = 'v0.0.2';
+
+

--- a/extras/kms/option.go
+++ b/extras/kms/option.go
@@ -31,7 +31,6 @@ type options struct {
 	withRandomReader   io.Reader
 	withReader         dbw.Reader
 	withWriter         dbw.Writer
-	withCache          bool
 	withScopeIds       []string
 	withRewrap         bool
 	withRootKeyId      string
@@ -126,13 +125,6 @@ func WithReaderWriter(r dbw.Reader, w dbw.Writer) Option {
 	return func(o *options) {
 		o.withReader = r
 		o.withWriter = w
-	}
-}
-
-// WithCache will enable the optional kms cache
-func WithCache(enable bool) Option {
-	return func(o *options) {
-		o.withCache = enable
 	}
 }
 

--- a/extras/kms/repository_data_key.go
+++ b/extras/kms/repository_data_key.go
@@ -23,6 +23,9 @@ func (r *repository) CreateDataKey(ctx context.Context, rkvWrapper wrapping.Wrap
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(reader dbw.Reader, w dbw.Writer) error {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			var err error
 			if returnedDk, returnedDv, err = createDataKeyTx(ctx, reader, w, rkvWrapper, purpose, key); err != nil {
 				return fmt.Errorf("%s: %w", op, err)
@@ -145,6 +148,9 @@ func (r *repository) DeleteDataKey(ctx context.Context, privateId string, opt ..
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			dk := k.Clone()
 			// no oplog entries for root keys
 			rowsDeleted, err = w.Delete(ctx, dk)

--- a/extras/kms/repository_data_key_version.go
+++ b/extras/kms/repository_data_key_version.go
@@ -55,6 +55,9 @@ func (r *repository) CreateDataKeyVersion(ctx context.Context, rkvWrapper wrappi
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) error {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			returnedKey = kv.Clone()
 			// no oplog entries for root key version
 			if err := create(ctx, w, returnedKey); err != nil {
@@ -122,6 +125,9 @@ func (r *repository) DeleteDataKeyVersion(ctx context.Context, privateId string,
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			dk := k.Clone()
 			// no oplog entries for the key version
 			rowsDeleted, err = w.Delete(ctx, dk)

--- a/extras/kms/repository_root_key.go
+++ b/extras/kms/repository_root_key.go
@@ -22,6 +22,9 @@ func (r *repository) CreateRootKey(ctx context.Context, keyWrapper wrapping.Wrap
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) error {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			var err error
 			if returnedRk, returnedKv, err = createRootKeyTx(ctx, w, keyWrapper, scopeId, key); err != nil {
 				return fmt.Errorf("%s: %w", op, err)
@@ -126,6 +129,9 @@ func (r *repository) DeleteRootKey(ctx context.Context, privateId string, opt ..
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			dk := k.Clone()
 			// no oplog entries for root keys
 			rowsDeleted, err = w.Delete(ctx, dk)

--- a/extras/kms/repository_root_key_version.go
+++ b/extras/kms/repository_root_key_version.go
@@ -68,6 +68,9 @@ func (r *repository) CreateRootKeyVersion(ctx context.Context, keyWrapper wrappi
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) error {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			returnedKey = kv.Clone()
 			if err := create(ctx, w, returnedKey); err != nil {
 				return fmt.Errorf("%s: %w", op, err)
@@ -111,6 +114,9 @@ func (r *repository) DeleteRootKeyVersion(ctx context.Context, privateId string,
 		opts.withRetryCnt,
 		dbw.ExpBackoff{},
 		func(_ dbw.Reader, w dbw.Writer) (err error) {
+			if err := updateKeyCollectionVersion(ctx, w); err != nil {
+				return err
+			}
 			dk := k.Clone()
 			// no oplog entries for root key version
 			rowsDeleted, err = w.Delete(ctx, dk)

--- a/extras/kms/repository_root_key_version_test.go
+++ b/extras/kms/repository_root_key_version_test.go
@@ -732,7 +732,6 @@ func Test_rotateRootKeyVersionTx(t *testing.T) {
 	rootWrapper := wrapping.NewTestWrapper([]byte(testDefaultWrapperSecret))
 	testRepo, err := newRepository(rw, rw)
 	require.NoError(t, err)
-	// important: don't enable caching for these tests.
 	testKms, err := New(rw, rw, []KeyPurpose{"database"})
 	require.NoError(t, err)
 	testKms.AddExternalWrapper(testCtx, KeyPurposeRootKey, rootWrapper)

--- a/extras/kms/repository_root_key_version_test.go
+++ b/extras/kms/repository_root_key_version_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestRepository_CreateRootKeyVersion(t *testing.T) {
 	t.Parallel()
+	testCtx := context.Background()
 	db, _ := TestDb(t)
 	rw := dbw.New(db)
 	wrapper := wrapping.NewTestWrapper([]byte(testDefaultWrapperSecret))
@@ -105,6 +106,10 @@ func TestRepository_CreateRootKeyVersion(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
+
+			prevVersion, err := currentCollectionVersion(testCtx, rw)
+			require.NoError(err)
+
 			k, err := tc.repo.CreateRootKeyVersion(context.Background(), tc.keyWrapper, tc.rootKeyId, tc.key, tc.opt...)
 			if tc.wantErr {
 				require.Error(err)
@@ -122,12 +127,17 @@ func TestRepository_CreateRootKeyVersion(t *testing.T) {
 			foundKey, err := tc.repo.LookupRootKeyVersion(context.Background(), tc.keyWrapper, k.PrivateId)
 			assert.NoError(err)
 			assert.Equal(k, foundKey)
+
+			currVersion, err := currentCollectionVersion(testCtx, rw)
+			require.NoError(err)
+			assert.Greater(currVersion, prevVersion)
 		})
 	}
 }
 
 func TestRepository_DeleteRootKeyVersion(t *testing.T) {
 	t.Parallel()
+	testCtx := context.Background()
 	db, _ := TestDb(t)
 	rw := dbw.New(db)
 	wrapper := wrapping.NewTestWrapper([]byte(testDefaultWrapperSecret))
@@ -212,6 +222,7 @@ func TestRepository_DeleteRootKeyVersion(t *testing.T) {
 				require.NoError(t, err)
 				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
 				mock.ExpectBegin()
+				mock.ExpectExec(`update kms_collection_version`).WillReturnResult(sqlmock.NewResult(1, 1))
 				mock.ExpectExec(`DELETE`).WillReturnError(errors.New("delete-error"))
 				mock.ExpectRollback()
 				return r
@@ -238,6 +249,7 @@ func TestRepository_DeleteRootKeyVersion(t *testing.T) {
 				require.NoError(t, err)
 				mock.ExpectQuery(`SELECT`).WillReturnRows(sqlmock.NewRows([]string{"scope_id", "create_time"}).AddRow(testScopeId, time.Now()))
 				mock.ExpectBegin()
+				mock.ExpectExec(`update kms_collection_version`).WillReturnResult(sqlmock.NewResult(1, 1))
 				mock.ExpectExec(`DELETE`).WillReturnResult(sqlmock.NewResult(0, 2))
 				mock.ExpectRollback()
 				return r
@@ -260,6 +272,10 @@ func TestRepository_DeleteRootKeyVersion(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
+
+			prevVersion, err := currentCollectionVersion(testCtx, rw)
+			require.NoError(err)
+
 			deletedRows, err := tc.repo.DeleteRootKeyVersion(context.Background(), tc.key.PrivateId, tc.opt...)
 			if tc.wantErr {
 				require.Error(err)
@@ -277,6 +293,10 @@ func TestRepository_DeleteRootKeyVersion(t *testing.T) {
 			assert.Error(err)
 			assert.Nil(foundKey)
 			assert.ErrorIs(err, ErrRecordNotFound)
+
+			currVersion, err := currentCollectionVersion(testCtx, rw)
+			require.NoError(err)
+			assert.Greater(currVersion, prevVersion)
 		})
 	}
 }

--- a/extras/kms/testing.go
+++ b/extras/kms/testing.go
@@ -202,7 +202,8 @@ func testSqliteSchemaAdditions(t *testing.T) string {
 }
 
 // testDeleteWhere allows you to easily delete resources for testing purposes
-// including all the current resources.
+// including all the current resources. The collection version is updated when
+// the resource is a key.
 func testDeleteWhere(t *testing.T, conn *dbw.DB, i interface{}, whereClause string, args ...interface{}) {
 	t.Helper()
 	require := require.New(t)
@@ -213,4 +214,10 @@ func testDeleteWhere(t *testing.T, conn *dbw.DB, i interface{}, whereClause stri
 	require.True(ok)
 	_, err := dbw.New(conn).Exec(ctx, fmt.Sprintf(`delete from "%s" where %s`, tabler.TableName(), whereClause), []interface{}{args})
 	require.NoError(err)
+
+	switch i.(type) {
+	case *rootKey, *rootKeyVersion, *dataKey, *dataKeyVersion:
+		require.NoError(err, updateKeyCollectionVersion(ctx, dbw.New(conn)))
+
+	}
 }


### PR DESCRIPTION
Add support for versioning the entire "collection" of keys represented
by the kms.

Any time one of the keys in the collection changes, the
version will be incremented.

Adding this capability will make it easy to invalidate the kms cache.
This is especially important when the cache is shared (distributed)
across multiple processes.

This change requires incrementing the migrations version.

Given the enhancements with how the cache is handled, we're going
to always enable it, so we need to remove it as an option