### PR TITLE
fix: Update DEK root key version id when rewrapping

### DIFF
--- a/extras/kms/migrations/postgres/07_mutable_root_key_version.up.sql
+++ b/extras/kms/migrations/postgres/07_mutable_root_key_version.up.sql
@@ -1,0 +1,12 @@
+begin;
+
+-- we need to make the root_key_version_id mutable in order to support
+-- rewrapping the data key version.
+drop trigger kms_immutable_columns on kms_data_key_version;
+
+create trigger kms_immutable_columns
+before
+update on kms_data_key_version
+  for each row execute procedure kms_immutable_columns('private_id', 'data_key_id', 'create_time');
+
+commit;

--- a/extras/kms/migrations/sqlite/07_mutable_root_key_version.up.sql
+++ b/extras/kms/migrations/sqlite/07_mutable_root_key_version.up.sql
@@ -1,0 +1,15 @@
+-- we need to make the root_key_version_id column mutable in order to support
+-- rewrapping the data key version.
+drop trigger kms_immutable_columns_kms_data_key_version;
+
+create trigger kms_immutable_columns_kms_data_key_version
+before update on kms_data_key_version
+for each row 
+  when 
+    new.private_id <> old.private_id or 
+    new.data_key_id <> old.data_key_id or
+    new.create_time <> old.create_time 
+	begin
+	  select raise(abort, 'immutable column');
+	end;
+  

--- a/extras/kms/repository_data_key_test.go
+++ b/extras/kms/repository_data_key_test.go
@@ -25,7 +25,7 @@ type mockTestWrapper struct {
 }
 
 func (m *mockTestWrapper) KeyId(context.Context) (string, error) {
-	if m.err != nil {
+	if m.err != nil && !m.encryptError && !m.decryptError {
 		return "", m.err
 	}
 	return m.keyId, nil


### PR DESCRIPTION
If the root key version id isn't updated when rewrapping, revoking the old key version will cause the DB to attempt to drop the data key.