### PR TITLE
Prevent setting duplicate wrapper

### DIFF
--- a/extras/multi/pooled.go
+++ b/extras/multi/pooled.go
@@ -116,6 +116,10 @@ func (m *PooledWrapper) SetEncryptingWrapper(ctx context.Context, w wrapping.Wra
 	m.m.Lock()
 	defer m.m.Unlock()
 
+	wrapper := m.wrappers[keyId]
+	if wrapper != nil {
+		return false, nil
+	}
 	m.wrappers[BaseEncryptor] = w
 	m.wrappers[keyId] = w
 	return true, nil


### PR DESCRIPTION
There was a check when trying to set a duplicate wrapper using AddWrapper, but SetEncryptingWrapper was missing it. Add the check and refactor the tests to make it easier to add more tests. Add tests for the new behavior.