### PR TITLE
Add LocationName method to GCP wrapper to facilitate certain GCP operation calls

### DIFF
--- a/wrappers/gcpckms/gcpckms.go
+++ b/wrappers/gcpckms/gcpckms.go
@@ -310,3 +310,8 @@ func (s *Wrapper) createClient() (*cloudkms.KeyManagementClient, error) {
 func (s *Wrapper) KeyRingResourceName() string {
 	return fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", s.project, s.location, s.keyRing)
 }
+
+// LocationName returns the relative location name.
+func (s *Wrapper) LocationName() string {
+	return fmt.Sprintf("projects/%s/locations/%s", s.project, s.location)
+}


### PR DESCRIPTION
# Summary
This is a helper function for certain GCP KMS client calls, similar to the existing `KeyRingResourceName`.