### PR TITLE
feature/refactor (extras/crypto): add Sha256SumWriter and refactor sha256sum to support WithHexEncoding

### DIFF
--- a/extras/crypto/options.go
+++ b/extras/crypto/options.go
@@ -137,6 +137,7 @@ func WithInfo(info []byte) wrapping.Option {
 	}
 }
 
+// WithHexEncoding allows an optional request to use hex encoding.
 func WithHexEncoding(withHexEncoding bool) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {

--- a/extras/crypto/options.go
+++ b/extras/crypto/options.go
@@ -47,6 +47,7 @@ type options struct {
 	withMarshaledSigInfo bool
 	withSalt             []byte
 	withInfo             []byte
+	WithHexEncoding      bool
 }
 
 func getDefaultOptions() options {
@@ -131,6 +132,15 @@ func WithInfo(info []byte) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {
 			o.withInfo = info
+			return nil
+		})
+	}
+}
+
+func WithHexEncoding(withHexEncoding bool) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.WithHexEncoding = withHexEncoding
 			return nil
 		})
 	}

--- a/extras/crypto/sha256sum.go
+++ b/extras/crypto/sha256sum.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
@@ -31,4 +32,77 @@ func Sha256Sum(ctx context.Context, r io.Reader) (string, error) {
 	hash := hasher.Sum(nil)
 	encodedHex := hex.EncodeToString(hash[:])
 	return encodedHex, nil
+}
+
+// Sha256SumWriter provides multi-writer which will be used to write to a
+// hash and produce a sum.  It implements io.Writer and optionally io.Closer
+type Sha256SumWriter struct {
+	hash hash.Hash
+	tee  io.Writer
+}
+
+// NewSha256SumWriter creates a new Sha256SumWriter
+func NewSha256SumWriter(ctx context.Context, w io.Writer) (*Sha256SumWriter, error) {
+	const op = "crypto.NewSha256SumWriter"
+	switch {
+	case isNil(w):
+		return nil, fmt.Errorf("%s: missing writer: %w", op, wrapping.ErrInvalidParameter)
+	}
+	h := sha256.New()
+	tee := io.MultiWriter(w, h)
+	return &Sha256SumWriter{
+		hash: h,
+		tee:  tee,
+	}, nil
+}
+
+// Write will write the bytes to the hash. Implements the required io.Writer
+// func.
+func (w *Sha256SumWriter) Write(b []byte) (int, error) {
+	const op = "crypto.(Sha256SumWriter).Write"
+	n, err := w.tee.Write(b)
+	if err != nil {
+		return n, fmt.Errorf("%s: %w", op, err)
+	}
+	return n, nil
+}
+
+// WriteString will write the string to hash.
+func (w *Sha256SumWriter) WriteString(s string) (int, error) {
+	const op = "crypto.(Sha256SumWriter).WriteString"
+	n, err := w.Write([]byte(s))
+	if err != nil {
+		return n, fmt.Errorf("%s: %w", op, err)
+	}
+	return n, nil
+}
+
+// Close checks to see if the Sha256SumWriter implements the optional io.Closer
+// and if so, then Close() is called; otherwise this is a noop
+func (w *Sha256SumWriter) Close() error {
+	const op = "crypto.(Sha256SumWriter).WriteString"
+	var i interface{} = w.tee
+	if v, ok := i.(io.Closer); ok {
+		if err := v.Close(); err != nil {
+			return fmt.Errorf("%s: %w", op, err)
+		}
+	}
+	return nil
+}
+
+// Sum will sum the hash.  Options supported: WithHexEncoding
+func (w *Sha256SumWriter) Sum(_ context.Context, opt ...wrapping.Option) ([]byte, error) {
+	const op = "crypto.(Sha256SumWriter).Sum"
+	opts, err := getOpts(opt...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", op, err)
+	}
+	h := w.hash.Sum(nil)
+	switch {
+	case opts.WithHexEncoding:
+		encodedHex := hex.EncodeToString(h[:])
+		return []byte(encodedHex), nil
+	default:
+		return h, nil
+	}
 }

--- a/extras/crypto/sha256sum.go
+++ b/extras/crypto/sha256sum.go
@@ -42,7 +42,7 @@ func Sha256Sum(ctx context.Context, r io.Reader, opt ...wrapping.Option) ([]byte
 }
 
 // Sha256SumWriter provides multi-writer which will be used to write to a
-// hash and produce a sum.  It implements io.Writer and optionally io.Closer
+// hash and produce a sum.  It implements io.WriterCloser and io.StringWriter.
 type Sha256SumWriter struct {
 	hash hash.Hash
 	tee  io.Writer

--- a/extras/crypto/sha256sum_test.go
+++ b/extras/crypto/sha256sum_test.go
@@ -5,6 +5,8 @@ package crypto_test
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"io/ioutil"
 	"os"
@@ -96,4 +98,115 @@ func TestSha256Sum(t *testing.T) {
 			assert.Equal(tc.wantSum, sum)
 		})
 	}
+}
+
+func TestSha256SumWriter_Sum(t *testing.T) {
+	t.Parallel()
+	testCtx := context.Background()
+	testBytes := []byte("test-bytes")
+	tests := []struct {
+		name            string
+		data            []byte
+		sumWriter       *crypto.Sha256SumWriter
+		opt             []wrapping.Option
+		wantSum         []byte
+		wantErr         bool
+		wantErrIs       error
+		wantErrContains string
+	}{
+		{
+			name: "success",
+			data: testBytes,
+			sumWriter: func() *crypto.Sha256SumWriter {
+				var b strings.Builder
+				w, err := crypto.NewSha256SumWriter(testCtx, &b)
+				require.NoError(t, err)
+				return w
+			}(),
+			wantSum: func() []byte {
+				hasher := sha256.New()
+				_, err := hasher.Write(testBytes)
+				require.NoError(t, err)
+				_, err = hasher.Write(testBytes)
+				require.NoError(t, err)
+				return hasher.Sum(nil)
+			}(),
+		},
+		{
+			name: "success-with-hex-encoding",
+			data: testBytes,
+			sumWriter: func() *crypto.Sha256SumWriter {
+				var b strings.Builder
+				w, err := crypto.NewSha256SumWriter(testCtx, &b)
+				require.NoError(t, err)
+				return w
+			}(),
+			opt: []wrapping.Option{crypto.WithHexEncoding(true)},
+			wantSum: func() []byte {
+				hasher := sha256.New()
+				_, err := hasher.Write(testBytes)
+				require.NoError(t, err)
+				_, err = hasher.Write(testBytes)
+				require.NoError(t, err)
+				h := hasher.Sum(nil)
+				return []byte(hex.EncodeToString(h[:]))
+			}(),
+		},
+		{
+			name: "success-with-closer",
+			data: testBytes,
+			sumWriter: func() *crypto.Sha256SumWriter {
+				c := closer{
+					b: strings.Builder{},
+				}
+				w, err := crypto.NewSha256SumWriter(testCtx, &c)
+				require.NoError(t, err)
+				return w
+			}(),
+			wantSum: func() []byte {
+				hasher := sha256.New()
+				_, err := hasher.Write(testBytes)
+				require.NoError(t, err)
+				_, err = hasher.Write(testBytes)
+				require.NoError(t, err)
+				return hasher.Sum(nil)
+			}(),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert, require := assert.New(t), require.New(t)
+			_, err := tc.sumWriter.Write(tc.data)
+			require.NoError(err)
+			_, err = tc.sumWriter.WriteString(string(tc.data))
+			require.NoError(err)
+			sum, err := tc.sumWriter.Sum(testCtx, tc.opt...)
+			if tc.wantErr {
+				require.Error(err)
+				assert.Empty(sum)
+				if tc.wantErrIs != nil {
+					assert.ErrorIs(err, tc.wantErrIs)
+				}
+				if tc.wantErrContains != "" {
+					assert.Contains(err.Error(), tc.wantErrContains)
+				}
+				return
+			}
+			require.NoError(err)
+			assert.Equal(tc.wantSum, sum)
+			require.NoError(tc.sumWriter.Close())
+		})
+	}
+}
+
+type closer struct {
+	b strings.Builder
+}
+
+func (w *closer) Write(b []byte) (int, error) {
+	return w.b.Write(b)
+}
+
+func (*closer) Close() error {
+	return nil
 }


### PR DESCRIPTION
Sha256SumWriter provides multi-writer which will be used to write to a hash and produce a sum.  It implements io.Writer and optionally io.Closer