### PR TITLE
fix(extras/crypto): Close underlying writer for Sha256SumWriter

### DIFF
--- a/extras/crypto/sha256sum.go
+++ b/extras/crypto/sha256sum.go
@@ -46,6 +46,7 @@ func Sha256Sum(ctx context.Context, r io.Reader, opt ...wrapping.Option) ([]byte
 type Sha256SumWriter struct {
 	hash hash.Hash
 	tee  io.Writer
+	w    io.Writer
 }
 
 // NewSha256SumWriter creates a new Sha256SumWriter
@@ -60,6 +61,7 @@ func NewSha256SumWriter(ctx context.Context, w io.Writer) (*Sha256SumWriter, err
 	return &Sha256SumWriter{
 		hash: h,
 		tee:  tee,
+		w:    w,
 	}, nil
 }
 
@@ -88,7 +90,7 @@ func (w *Sha256SumWriter) WriteString(s string) (int, error) {
 // and if so, then Close() is called; otherwise this is a noop
 func (w *Sha256SumWriter) Close() error {
 	const op = "crypto.(Sha256SumWriter).WriteString"
-	var i interface{} = w.tee
+	var i interface{} = w.w
 	if v, ok := i.(io.Closer); ok {
 		if err := v.Close(); err != nil {
 			return fmt.Errorf("%s: %w", op, err)


### PR DESCRIPTION
A call to Close on a Sha256SumWriter would check if the io.MultiWriter
was an io.Closer and call Close on it. However, an io.MultiWriter does
not implement io.Closer, so the type assertion would never be true. Thus
if the initial io.Writer that is given to the Sha256SumWriter
implemented io.Closer, it would never be called.

This updates the Sha256SumWriter to keep a reference to the original
io.Writer, so it can perform the check against it and call the correct
Close. This allows Sha256SumWriter to be used as a transparent wrapper
of a io.WriteCloser.