### PR TITLE
Add a codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+**     @hashicorp/vault-crypto @hashicorp/boundary
+


### PR DESCRIPTION
For now, it assigns the entire codebase to both Vault Crypto and Boundary.