### PR TITLE
Key id needs to be more specific than just the version in order to use Seal HA with multiple transit seals

### DIFF
--- a/wrappers/transit/transit.go
+++ b/wrappers/transit/transit.go
@@ -18,7 +18,9 @@ import (
 type Wrapper struct {
 	logger       hclog.Logger
 	client       transitClientEncryptor
+	keyName      string
 	currentKeyId *atomic.Value
+	keyIdPrefix  string
 }
 
 var _ wrapping.Wrapper = (*Wrapper)(nil)
@@ -46,6 +48,8 @@ func (s *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 		return nil, err
 	}
 	s.client = client
+
+	s.keyIdPrefix = client.mountPath + "/" + client.keyName + "/"
 
 	// Send a value to test the wrapper and to set the current key id
 	if _, err := s.Encrypt(context.Background(), []byte("a")); err != nil {
@@ -88,7 +92,7 @@ func (s *Wrapper) Encrypt(_ context.Context, plaintext []byte, _ ...wrapping.Opt
 	if len(splitKey) != 3 {
 		return nil, errors.New("invalid ciphertext returned")
 	}
-	keyId := splitKey[1]
+	keyId := s.keyIdPrefix + splitKey[1]
 	s.currentKeyId.Store(keyId)
 
 	ret := &wrapping.BlobInfo{


### PR DESCRIPTION
Don't merge yet, need to think about backwards compatibility