### PR TITLE
Provide a keyId prefix as an option to transit wrappers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/go-kms-wrapping/v2
 go 1.20
 
 require (
-	github.com/favadi/protoc-go-inject-tag v1.4.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/mr-tron/base58 v1.2.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/favadi/protoc-go-inject-tag v1.4.0 h1:K3KXxbgRw5WT4f43LbglARGz/8jVsDOS7uMjG4oNvXY=
-github.com/favadi/protoc-go-inject-tag v1.4.0/go.mod h1:AZ+PK+QDKUOLlBRG0rYiKkUX5Hw7+7GTFzlU99GFSbQ=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=

--- a/wrappers/transit/options.go
+++ b/wrappers/transit/options.go
@@ -73,6 +73,8 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 				if err != nil {
 					return nil, err
 				}
+			case "key_id_prefix":
+				opts.withKeyIdPrefix = v
 			case "token":
 				opts.withToken = v
 			}
@@ -111,6 +113,7 @@ type options struct {
 	withTlsServerName  string
 	withTlsSkipVerify  bool
 	withToken          string
+	withKeyIdPrefix    string
 
 	withLogger hclog.Logger
 }
@@ -244,6 +247,16 @@ func WithLogger(with hclog.Logger) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {
 			o.withLogger = with
+			return nil
+		})
+	}
+}
+
+// WithKeyIdPrefix specifies a prefix to prepend to the keyId (key version)
+func WithKeyIdPrefix(with string) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.withKeyIdPrefix = with
 			return nil
 		})
 	}

--- a/wrappers/transit/transit.go
+++ b/wrappers/transit/transit.go
@@ -19,6 +19,7 @@ type Wrapper struct {
 	logger       hclog.Logger
 	client       transitClientEncryptor
 	currentKeyId *atomic.Value
+	keyIdPrefix  string
 }
 
 var _ wrapping.Wrapper = (*Wrapper)(nil)
@@ -46,6 +47,7 @@ func (s *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 		return nil, err
 	}
 	s.client = client
+	s.keyIdPrefix = opts.withKeyIdPrefix
 
 	// Send a value to test the wrapper and to set the current key id
 	if _, err := s.Encrypt(context.Background(), []byte("a")); err != nil {
@@ -88,7 +90,7 @@ func (s *Wrapper) Encrypt(_ context.Context, plaintext []byte, _ ...wrapping.Opt
 	if len(splitKey) != 3 {
 		return nil, errors.New("invalid ciphertext returned")
 	}
-	keyId := splitKey[1]
+	keyId := s.keyIdPrefix + splitKey[1]
 	s.currentKeyId.Store(keyId)
 
 	ret := &wrapping.BlobInfo{

--- a/wrappers/transit/transit_test.go
+++ b/wrappers/transit/transit_test.go
@@ -17,6 +17,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testWithMountPath      = "transit/"
+	testWithAddress        = "http://localhost:8200"
+	testWithKeyName        = "example-key"
+	testWithDisableRenewal = "true"
+	testWithNamespace      = "ns1/"
+	testWithToken          = "vault-plaintext-root-token"
+
+	envVaultNamespace = "VAULT_NAMESPACE"
+)
+
 type testTransitClient struct {
 	keyID string
 	wrap  wrapping.Wrapper
@@ -86,20 +97,23 @@ func TestTransitWrapper_Lifecycle(t *testing.T) {
 	if kid != keyId {
 		t.Fatalf("key id does not match: expected %s, got %s", keyId, kid)
 	}
+
+	// Test keyId prefix (can't use the option/SetConfig however )
+	s.keyIdPrefix = "test/"
+	_, err = s.Encrypt(context.Background(), input)
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	kid, err = s.KeyId(context.Background())
+	if err != nil {
+		t.Fatalf("err: %s", err.Error())
+	}
+	if kid != "test/"+keyId {
+		t.Fatalf("key id does not match: expected %s, got %s", keyId, kid)
+	}
 }
 
 func TestSetConfig(t *testing.T) {
-	const (
-		testWithMountPath      = "transit/"
-		testWithAddress        = "http://localhost:8200"
-		testWithKeyName        = "example-key"
-		testWithDisableRenewal = "true"
-		testWithNamespace      = "ns1/"
-		testWithToken          = "vault-plaintext-root-token"
-
-		envVaultNamespace = "VAULT_NAMESPACE"
-	)
-
 	tests := []struct {
 		name            string
 		opts            []wrapping.Option
@@ -292,6 +306,7 @@ func TestSetConfig(t *testing.T) {
 				WithMountPath(testWithMountPath),
 				WithKeyName(testWithKeyName),
 				WithNamespace(testWithNamespace),
+				WithKeyIdPrefix("test/"),
 			},
 		},
 	}


### PR DESCRIPTION
This allows Vault's seal subsystem to distinguish between two transit wrappers by passing a distinct prefix for each, but doesn't affect keyId for other consumers.