### PR TITLE
fix (extras/kms): fix adding external key to cache without a key id

### DIFF
--- a/extras/kms/kms.go
+++ b/extras/kms/kms.go
@@ -122,13 +122,6 @@ func (k *Kms) addKey(ctx context.Context, cPurpose cachePurpose, kPurpose KeyPur
 
 	opts := getOpts(opt...)
 
-	keyVersionId, err := wrapper.KeyId(ctx)
-	if err != nil {
-		return fmt.Errorf("%s: error reading wrapper key ID: %w", op, err)
-	}
-	if keyVersionId == missingId {
-		return fmt.Errorf("%s: wrapper has no key version ID: %w", op, ErrInvalidParameter)
-	}
 	switch cPurpose {
 	case externalWrapperCache:
 		k.externalWrapperCache.Store(kPurpose, wrapper)

--- a/extras/kms/kms_test.go
+++ b/extras/kms/kms_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2"
 	"github.com/hashicorp/go-kms-wrapping/extras/kms/v2/migrations"
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/hashicorp/go-kms-wrapping/v2/aead"
 	"github.com/hashicorp/go-kms-wrapping/v2/extras/multi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,27 +136,6 @@ func TestKms_AddExternalWrapper(t *testing.T) {
 			wantErr:         true,
 			wantErrIs:       kms.ErrInvalidParameter,
 			wantErrContains: "not a supported key purpose",
-		},
-		{
-			name:            "wrapper-key-id-error",
-			reader:          rw,
-			writer:          rw,
-			kmsPurposes:     []kms.KeyPurpose{"recovery"},
-			wrapper:         &mockTestWrapper{err: errors.New("KeyId error")},
-			wrapperPurpose:  "recovery",
-			wantErr:         true,
-			wantErrContains: "KeyId error",
-		},
-		{
-			name:            "wrapper-missing-key-id",
-			reader:          rw,
-			writer:          rw,
-			kmsPurposes:     []kms.KeyPurpose{"recovery"},
-			wrapper:         aead.NewWrapper(),
-			wrapperPurpose:  "recovery",
-			wantErr:         true,
-			wantErrIs:       kms.ErrInvalidParameter,
-			wantErrContains: "wrapper has no key version ID",
 		},
 		{
 			name:           "success-non-default-purpose",


### PR DESCRIPTION
We had an unnecessary check for an external wrappers key id before adding it to the cache.

Besides being unnecessary, the check can caused problems with external wrappers that don't determine a key id until they've completed a successful encryption operation.