### PR TITLE
chore: update aws sdk dep

### DIFF
--- a/wrappers/awskms/go.mod
+++ b/wrappers/awskms/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2
 go 1.20
 
 require (
-	github.com/aws/aws-sdk-go v1.44.210
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.14

--- a/wrappers/awskms/go.sum
+++ b/wrappers/awskms/go.sum
@@ -1,6 +1,8 @@
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.44.210 h1:/cqRMHSSgzLEKILIDGwhaX2hiIpyRurw7MRy6aaSufg=
 github.com/aws/aws-sdk-go v1.44.210/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
+github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
+github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
# Summary

This PR updates the aws-sdk-go version from `v1.44.210` to `v1.55.5` for the awskms wrapper. This PR was opened because a customer for Boundary requested the support of using EKS Pod Identity credentials. This [aws document](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-minimum-sdk.html) states that the minimum required aws-sdk-go version for EKS Pod Identity credentials is Go v1 – [v1.47.11](https://github.com/aws/aws-sdk-go/releases/tag/v1.47.11)

