### PR TITLE
Fix incompatibility between workload identity and managed identity auth

### DIFF
--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -300,7 +300,8 @@ func (v *Wrapper) getKeyVaultClient(withCertPool *x509.CertPool) (*azkeys.Client
 			return nil, fmt.Errorf("failed to get client secret credentials %w", err)
 		}
 	case v.clientID != "":
-		// Set an env var with the client id, and let the default credential provider work through the possibilities
+		// This could be a managed identity auth, so supply the default credential provider with clientId and let it
+		// figure it out.
 		os.Setenv(EnvAzureClientId, v.clientID)
 		fallthrough
 	// By default let Azure select existing credentials

--- a/wrappers/azurekeyvault/azurekeyvault.go
+++ b/wrappers/azurekeyvault/azurekeyvault.go
@@ -306,9 +306,13 @@ func (v *Wrapper) getKeyVaultClient(withCertPool *x509.CertPool) (*azkeys.Client
 		// Some hoops to jump through to make sure two wrappers being setup at the same time don't step on the
 		// env var
 		managedClientIdLock.Lock()
-		oldVal := os.Getenv(EnvAzureClientId)
+		oldVal, found := os.LookupEnv(EnvAzureClientId)
 		unlock := func() {
-			os.Setenv(EnvAzureClientId, oldVal)
+			if found {
+				os.Setenv(EnvAzureClientId, oldVal)
+			} else {
+				os.Unsetenv(EnvAzureClientId)
+			}
 			managedClientIdLock.Unlock()
 		}
 

--- a/wrappers/azurekeyvault/main.go
+++ b/wrappers/azurekeyvault/main.go
@@ -1,1 +1,0 @@
-package azurekeyvault

--- a/wrappers/azurekeyvault/main.go
+++ b/wrappers/azurekeyvault/main.go
@@ -1,0 +1,1 @@
+package azurekeyvault


### PR DESCRIPTION
The default credential provider _does_ handle managed service identities, but can only get the client id from an env var.  Supply it via env var (as there is no way in the Azure API to do so), but rely on the default credential provider to decide which auth pattern to use.