### PR TITLE
Add a WithoutEnvelope option

### DIFF
--- a/github.com.hashicorp.go.kms.wrapping.v2.types.pb.go
+++ b/github.com.hashicorp.go.kms.wrapping.v2.types.pb.go
@@ -696,6 +696,8 @@ type Options struct {
 	WithDisallowEnvVars    bool        `protobuf:"varint,90,opt,name=with_disallow_env_vars,json=withDisallowEnvVars,proto3" json:"with_disallow_env_vars,omitempty"`
 	// WithoutHmac specifies that an HMAC is not necessary for the mechanism, even if marked as "required"
 	WithoutHmac bool `protobuf:"varint,100,opt,name=without_hmac,json=withoutHmac,proto3" json:"without_hmac,omitempty"`
+	// WithoutEnvelope specifies that encryption should be over the plaintext rather than using an envelope encryption pattern
+	WithoutEnvelope bool `protobuf:"varint,100,opt,name=without_envelope,json=withoutEnvelope,proto3" json:"without_envelope,omitempty"`
 }
 
 func (x *Options) Reset() {

--- a/options.go
+++ b/options.go
@@ -156,6 +156,16 @@ func WithoutHMAC() Option {
 	}
 }
 
+// WithoutEnvelope requests a 'raw' encryption, rather than an envelope encryption
+func WithoutEnvelope() Option {
+	return func() interface{} {
+		return OptionFunc(func(o *Options) error {
+			o.WithoutEnvelope = true
+			return nil
+		})
+	}
+}
+
 // ParsePaths is a helper function to take each string pointer argument and call parseutil.ParsePath,
 // replacing the contents of the target string with the result if no error occurs.  The function exits
 // early if it encounters an error.  In that case no passed fields will have been modified.


### PR DESCRIPTION
Many wrappers assume an envelope encryption pattern due to limited encrypted
value sizes and the original use case of seal/seal wrap.  But managed keys
provides generic encryption backed by the wrappers.  Add an option that
indicates we don't want to use envelope encryption.  Would have preferred
WithEnvelope but this is backwards compatible.