### PR TITLE
Use AWS KMS key ARN as the key ID

### DIFF
--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -154,7 +154,7 @@ func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 			if keyInfo == nil || keyInfo.KeyMetadata == nil || keyInfo.KeyMetadata.KeyId == nil {
 				return nil, errors.New("no key information returned")
 			}
-			k.currentKeyId.Store(*keyInfo.KeyMetadata.KeyId)
+			k.currentKeyId.Store(*keyInfo.KeyMetadata.Arn)
 		}
 
 		k.client = client

--- a/wrappers/awskms/go.mod
+++ b/wrappers/awskms/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v3
+module github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v4
 
 go 1.24.0
 


### PR DESCRIPTION
## PCI review checklist
This PR resolves the go-kms-wrapping part of [ICU-18304](https://hashicorp.atlassian.net/browse/ICU-18304). [Context](https://ibm-hashicorp.slack.com/archives/C09L3DN152Q/p1767820327775139).

After the first call to Encrypt, the aws wrapper will set its currentKeyId to the ARN of the key used. This instead sets the key id at SetConfig time so client code doesn't have to deal with changing key IDs for the same key. 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

[ICU-18304]: https://hashicorp.atlassian.net/browse/ICU-18304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ