### PR TITLE
fix(ocikms): guard retry policy against nil OCIResponse

### DIFF
--- a/wrappers/ocikms/ocikms.go
+++ b/wrappers/ocikms/ocikms.go
@@ -367,13 +367,27 @@ func (k *Wrapper) getOciKmsManagementClient() (*keymanagement.KmsManagementClien
 	return &kmsManagementClient, nil
 }
 
+// shouldRetryOn5xx is the retry predicate used by getRequestMetadata. It
+// returns true only when the OCI SDK reports an error accompanied by a real
+// HTTP response with a 5xx status code.
+//
+// When the OCI SDK fails before any HTTP round-trip occurs (for example when
+// an Instance/Resource Principal signer cannot be built), it produces
+// OCIOperationResponse{Error: <signer error>, Response: nil}. Guarding
+// against the nil OCIResponse and a nil *http.Response from HTTPResponse()
+// keeps the retry policy from panicking and lets the original error bubble
+// up to the caller.
+func shouldRetryOn5xx(r common.OCIOperationResponse) bool {
+	if r.Error == nil || r.Response == nil {
+		return false
+	}
+	httpResp := r.Response.HTTPResponse()
+	return httpResp != nil && httpResp.StatusCode >= 500
+}
+
 // Request metadata includes retry policy
 func (k *Wrapper) getRequestMetadata() common.RequestMetadata {
-	// Only retry for 5xx errors
-	retryOn5xxFunc := func(r common.OCIOperationResponse) bool {
-		return r.Error != nil && r.Response.HTTPResponse().StatusCode >= 500
-	}
-	return getRequestMetadataWithCustomizedRetryPolicy(retryOn5xxFunc)
+	return getRequestMetadataWithCustomizedRetryPolicy(shouldRetryOn5xx)
 }
 
 func getRequestMetadataWithCustomizedRetryPolicy(fn func(r common.OCIOperationResponse) bool) common.RequestMetadata {

--- a/wrappers/ocikms/ocikms_test.go
+++ b/wrappers/ocikms/ocikms_test.go
@@ -2,13 +2,99 @@
 package ocikms
 
 import (
+	"errors"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/oracle/oci-go-sdk/v60/common"
 	"golang.org/x/net/context"
 )
+
+// fakeOCIResponse implements common.OCIResponse and returns the embedded
+// *http.Response (which may itself be nil) from HTTPResponse().
+type fakeOCIResponse struct {
+	httpResp *http.Response
+}
+
+func (f *fakeOCIResponse) HTTPResponse() *http.Response { return f.httpResp }
+
+func TestShouldRetryOn5xx(t *testing.T) {
+	tests := []struct {
+		name string
+		op   common.OCIOperationResponse
+		want bool
+	}{
+		{
+			name: "no error and no response",
+			op:   common.OCIOperationResponse{},
+			want: false,
+		},
+		{
+			// Regression: the OCI SDK produces OCIOperationResponse{Error: ..., Response: nil}
+			// when the configuration provider (Instance/Resource Principal) fails to build
+			// credentials before any HTTP round-trip occurs. The retry predicate must
+			// not dereference Response in that case.
+			name: "error with nil response does not panic and does not retry",
+			op: common.OCIOperationResponse{
+				Error:    errors.New("failed to build signer"),
+				Response: nil,
+			},
+			want: false,
+		},
+		{
+			// Defensive: even when Response is non-nil, its HTTPResponse() may be nil
+			// (for example when the SDK populated a typed response without an
+			// http.Response).
+			name: "error with response but nil HTTPResponse does not retry",
+			op: common.OCIOperationResponse{
+				Error:    errors.New("transport failure"),
+				Response: &fakeOCIResponse{httpResp: nil},
+			},
+			want: false,
+		},
+		{
+			name: "error with 4xx response does not retry",
+			op: common.OCIOperationResponse{
+				Error:    errors.New("unauthorized"),
+				Response: &fakeOCIResponse{httpResp: &http.Response{StatusCode: http.StatusUnauthorized}},
+			},
+			want: false,
+		},
+		{
+			name: "error with 5xx response retries",
+			op: common.OCIOperationResponse{
+				Error:    errors.New("internal server error"),
+				Response: &fakeOCIResponse{httpResp: &http.Response{StatusCode: http.StatusInternalServerError}},
+			},
+			want: true,
+		},
+		{
+			name: "no error but 5xx response does not retry",
+			op: common.OCIOperationResponse{
+				Response: &fakeOCIResponse{httpResp: &http.Response{StatusCode: http.StatusInternalServerError}},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// The historical bug was a panic, so guard against re-introduction.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("shouldRetryOn5xx panicked: %v", r)
+				}
+			}()
+			if got := shouldRetryOn5xx(tc.op); got != tc.want {
+				t.Fatalf("shouldRetryOn5xx() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
 
 /*
 * To run these tests, ensure you setup:


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert is straightforward (single-package change, no API/storage migration).

- [x] If applicable, I've documented the impact of any changes to security controls.

  This change does not alter access control, logging, or cryptographic behaviour. It removes a nil pointer dereference in the OCI KMS retry predicate so that the underlying authentication error surfaces to the caller instead of a panic.

---

Fixes #324.

The retry predicate in `(*Wrapper).getRequestMetadata` called `r.Response.HTTPResponse()` whenever `r.Error != nil`. When the OCI SDK fails before any HTTP round-trip (e.g. an Instance/Resource Principal signer cannot be built), it produces `OCIOperationResponse{Error: ..., Response: nil}`, making the retry loop panic with a nil pointer dereference and hiding the original authentication error.

This PR extracts the predicate as `shouldRetryOn5xx`, returns `false` when `Error` or `Response` is nil, also tolerates a nil `*http.Response` from `HTTPResponse()`, and adds a table-driven regression test that locally reproduces the original panic against the unpatched function.

Local results:
- `go test -race ./...` in `wrappers/ocikms` passes.
- `go vet ./...` and `gofmt` clean.
- New `TestShouldRetryOn5xx` reproduces the panic on the pre-fix function and passes on the fixed function.
