### PR TITLE
Add a function to get an AWS client in a particular region

### DIFF
--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -326,6 +326,11 @@ func (k *Wrapper) Client() KmsApi {
 
 // GetAwsKmsClient returns an instance of the KMS client.
 func (k *Wrapper) GetAwsKmsClient(ctx context.Context) (*kms.Client, error) {
+	return k.GetAwsKmsClientInRegion(ctx, k.region)
+}
+
+// GetAwsKmsClient returns an instance of the KMS client in a different region than the wrapper config
+func (k *Wrapper) GetAwsKmsClientInRegion(ctx context.Context, region string) (*kms.Client, error) {
 	credsConfig := &awsutil.CredentialsConfig{
 		AccessKey:            k.accessKey,
 		SecretKey:            k.secretKey,
@@ -335,7 +340,7 @@ func (k *Wrapper) GetAwsKmsClient(ctx context.Context) (*kms.Client, error) {
 		RoleARN:              k.roleArn,
 		RoleSessionName:      k.roleSessionName,
 		WebIdentityTokenFile: k.webIdentityTokenFile,
-		Region:               k.region,
+		Region:               region,
 		Logger:               k.logger,
 		HTTPClient:           cleanhttp.DefaultClient(),
 	}

--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -331,6 +331,9 @@ func (k *Wrapper) GetAwsKmsClient(ctx context.Context) (*kms.Client, error) {
 
 // GetAwsKmsClient returns an instance of the KMS client in a different region than the wrapper config
 func (k *Wrapper) GetAwsKmsClientInRegion(ctx context.Context, region string) (*kms.Client, error) {
+	if region == "" {
+		region = k.region
+	}
 	credsConfig := &awsutil.CredentialsConfig{
 		AccessKey:            k.accessKey,
 		SecretKey:            k.secretKey,


### PR DESCRIPTION
In go-kms-wrapping-enterprise, this is used extensively.  Prior to v4 of the wrapper, it accomplished this
by cloning the "config" member of the wrapper client and building it's own client from it.
In v4, config is no longer exposed and so not available for cloning.  Instead, promote this pattern in the base
wrapper for cleanliness.


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.