### PR TITLE
default AEAD code paths to use stdlib provided random IV

### DIFF
--- a/aead/aead.go
+++ b/aead/aead.go
@@ -182,7 +182,7 @@ func (s *Wrapper) SetAesGcmKeyBytes(key []byte) error {
 		return err
 	}
 
-	aead, err := cipher.NewGCM(aesCipher)
+	aead, err := cipher.NewGCMWithRandomNonce(aesCipher)
 	if err != nil {
 		return err
 	}
@@ -226,20 +226,29 @@ func (s *Wrapper) Encrypt(_ context.Context, plaintext []byte, opt ...wrapping.O
 		return nil, err
 	}
 
-	if opts.WithRandomReader == nil {
-		opts.WithRandomReader = rand.Reader
+	var iv []byte
+	aead := s.aead
+
+	if opts.WithRandomReader != rand.Reader {
+		aesCipher, err := aes.NewCipher(s.keyBytes)
+		if err != nil {
+			return nil, err
+		}
+		aead, err = cipher.NewGCM(aesCipher)
+		if err != nil {
+			return nil, err
+		}
+		iv = make([]byte, 12)
+		n, err := opts.WithRandomReader.Read(iv)
+		if err != nil {
+			return nil, err
+		}
+		if n != 12 {
+			return nil, fmt.Errorf("expected to read %d bytes for iv, got %d", 12, n)
+		}
 	}
 
-	iv := make([]byte, 12)
-	n, err := opts.WithRandomReader.Read(iv)
-	if err != nil {
-		return nil, err
-	}
-	if n != 12 {
-		return nil, fmt.Errorf("expected to read %d bytes for iv, got %d", 12, n)
-	}
-
-	ciphertext := s.aead.Seal(nil, iv, plaintext, opts.WithAad)
+	ciphertext := aead.Seal(nil, iv, plaintext, opts.WithAad)
 
 	return &wrapping.BlobInfo{
 		Ciphertext: append(iv, ciphertext...),
@@ -269,9 +278,7 @@ func (s *Wrapper) Decrypt(_ context.Context, in *wrapping.BlobInfo, opt ...wrapp
 		return nil, err
 	}
 
-	iv, ciphertext := in.Ciphertext[:12], in.Ciphertext[12:]
-
-	plaintext, err := s.aead.Open(nil, iv, ciphertext, opts.WithAad)
+	plaintext, err := s.aead.Open(nil, nil, in.Ciphertext, opts.WithAad)
 	if err != nil {
 		return nil, err
 	}

--- a/envelope.go
+++ b/envelope.go
@@ -6,7 +6,6 @@ package wrapping
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"errors"
 	fmt "fmt"
 
 	uuid "github.com/hashicorp/go-uuid"
@@ -39,20 +38,21 @@ func EnvelopeEncrypt(plaintext []byte, opt ...Option) (*EnvelopeInfo, error) {
 			return nil, fmt.Errorf("invalid IV provided: expected 12 bytes, got %d", len(opts.WithIv))
 		}
 		iv = opts.WithIv
-	} else {
-		iv, err = uuid.GenerateRandomBytes(12)
-		if err != nil {
-			return nil, err
-		}
 	}
 
-	aead, err := aeadEncrypter(key)
+	aead, err := aeadEncrypter(key, opts.WithIv != nil)
 	if err != nil {
 		return nil, err
 	}
 
+	ciphertext := aead.Seal(nil, iv, plaintext, opts.WithAad)
+	if opts.WithIv == nil {
+		iv = ciphertext[:12]
+		ciphertext = ciphertext[12:]
+	}
+
 	return &EnvelopeInfo{
-		Ciphertext: aead.Seal(nil, iv, plaintext, opts.WithAad),
+		Ciphertext: ciphertext,
 		Key:        key,
 		Iv:         iv,
 	}, nil
@@ -77,24 +77,34 @@ func EnvelopeDecrypt(data *EnvelopeInfo, opt ...Option) ([]byte, error) {
 		return nil, err
 	}
 
-	aead, err := aeadEncrypter(data.Key)
+	aead, err := aeadEncrypter(data.Key, false)
 	if err != nil {
 		return nil, err
 	}
-
-	return aead.Open(nil, data.Iv, data.Ciphertext, opts.WithAad)
+	ciphertext := append(data.Iv, data.Ciphertext...)
+	return aead.Open(nil, nil, ciphertext, opts.WithAad)
 }
 
-func aeadEncrypter(key []byte) (cipher.AEAD, error) {
+func aeadEncrypter(key []byte, withIV bool) (cipher.AEAD, error) {
+
 	aesCipher, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
 
+	if withIV {
+		gcm, err := cipher.NewGCM(aesCipher)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize GCM mode: %w", err)
+		}
+
+		return gcm, nil
+	}
+
 	// Create the GCM mode AEAD
-	gcm, err := cipher.NewGCM(aesCipher)
+	gcm, err := cipher.NewGCMWithRandomNonce(aesCipher)
 	if err != nil {
-		return nil, errors.New("failed to initialize GCM mode")
+		return nil, fmt.Errorf("failed to initialize GCM mode: %w", err)
 	}
 
 	return gcm, nil

--- a/envelope.go
+++ b/envelope.go
@@ -11,6 +11,8 @@ import (
 	uuid "github.com/hashicorp/go-uuid"
 )
 
+const nonceSize = 12
+
 // EnvelopeEncrypt takes in plaintext and envelope encrypts it, generating an
 // EnvelopeInfo value.  An empty plaintext is a valid parameter and will not cause
 // an error.  Also note: if you provide a plaintext of []byte(""),
@@ -34,8 +36,8 @@ func EnvelopeEncrypt(plaintext []byte, opt ...Option) (*EnvelopeInfo, error) {
 
 	var iv []byte
 	if opts.WithIv != nil {
-		if len(opts.WithIv) != 12 {
-			return nil, fmt.Errorf("invalid IV provided: expected 12 bytes, got %d", len(opts.WithIv))
+		if len(opts.WithIv) != nonceSize {
+			return nil, fmt.Errorf("invalid IV provided: expected %d bytes, got %d", nonceSize, len(opts.WithIv))
 		}
 		iv = opts.WithIv
 	}
@@ -47,8 +49,8 @@ func EnvelopeEncrypt(plaintext []byte, opt ...Option) (*EnvelopeInfo, error) {
 
 	ciphertext := aead.Seal(nil, iv, plaintext, opts.WithAad)
 	if opts.WithIv == nil {
-		iv = ciphertext[:12]
-		ciphertext = ciphertext[12:]
+		iv = ciphertext[:nonceSize]
+		ciphertext = ciphertext[nonceSize:]
 	}
 
 	return &EnvelopeInfo{

--- a/envelope_test.go
+++ b/envelope_test.go
@@ -260,7 +260,7 @@ func Test_aeadEncrypter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert, require := assert.New(t), require.New(t)
 
-			got, err := aeadEncrypter(tc.key)
+			got, err := aeadEncrypter(tc.key, false)
 			if tc.wantErr {
 				require.Error(err)
 				if tc.wantErrContains != "" {

--- a/options.go
+++ b/options.go
@@ -5,6 +5,7 @@ package wrapping
 
 import (
 	"errors"
+
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 )
 
@@ -86,6 +87,11 @@ func WithKeyType(keyType KeyType) Option {
 }
 
 // WithRandomBytes provides a common way to pass in entropy
+//
+// Deprecated: without this option, the library will use a secure cryptographic
+// source of entropy from the stdlib. This option cannot be used with the Go
+// Cryptographic Module for FIPS compliance and operations will return errors if
+// GODEBUG=fips140=only
 func WithRandomBytes(b []byte) Option {
 	return func() interface{} {
 		return OptionFunc(func(o *Options) error {
@@ -106,7 +112,12 @@ func WithConfigMap(with map[string]string) Option {
 	}
 }
 
-// WithIV provides
+// WithIV provides a specific IV for an operation.
+//
+// Deprecated: without this option, the library will use a secure cryptographic
+// source of entropy from the stdlib to generate an IV. This option cannot be
+// used with the Go Cryptographic Module for FIPS compliance and operations will
+// return errors if GODEBUG=fips140=only
 func WithIV(with []byte) Option {
 	return func() interface{} {
 		return OptionFunc(func(o *Options) error {

--- a/options.go
+++ b/options.go
@@ -88,9 +88,9 @@ func WithKeyType(keyType KeyType) Option {
 
 // WithRandomBytes provides a common way to pass in entropy
 //
-// Deprecated: without this option, the library will use a secure cryptographic
-// source of entropy from the stdlib. This option cannot be used with the Go
-// Cryptographic Module for FIPS compliance and operations will return errors if
+// Without this option, the library will use a secure cryptographic source of
+// entropy from the stdlib. This option cannot be used with the Go Cryptographic
+// Module for FIPS compliance and operations will return errors if
 // GODEBUG=fips140=only
 func WithRandomBytes(b []byte) Option {
 	return func() interface{} {
@@ -114,10 +114,10 @@ func WithConfigMap(with map[string]string) Option {
 
 // WithIV provides a specific IV for an operation.
 //
-// Deprecated: without this option, the library will use a secure cryptographic
-// source of entropy from the stdlib to generate an IV. This option cannot be
-// used with the Go Cryptographic Module for FIPS compliance and operations will
-// return errors if GODEBUG=fips140=only
+// Without this option, the library will use a secure cryptographic source of
+// entropy from the stdlib to generate an IV. This option cannot be used with
+// the Go Cryptographic Module for FIPS compliance and operations will return
+// errors if GODEBUG=fips140=only
 func WithIV(with []byte) Option {
 	return func() interface{} {
 		return OptionFunc(func(o *Options) error {


### PR DESCRIPTION
When built with the Go Cryptographic Module for FIPS-140 compliance, and running in "enforcing mode" of `GODEBUG=fips140=only`, AEAD and envelope operations will fail with an error that you must use `NewGCMWithRandomNonce` rather than supplying your own IV. But if you supply a non-empty IV to `NewGCMWithRandomNonce`, that will also return an error.

This changeset updates the library to deprecate supplying your own IV, and updates the seal/unseal paths to backwards-compatibly avoid generating one in the library itself rather than using the one supplied by the stdlib.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658

See notes on my end-to-end testing below.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.