### PR TITLE
Make it possible to specify role_external_id for AWS wrappers

### DIFF
--- a/wrappers/awskms/awskms.go
+++ b/wrappers/awskms/awskms.go
@@ -47,6 +47,7 @@ type Wrapper struct {
 	sharedCredsFilename  string
 	sharedCredsProfile   string
 	roleArn              string
+	roleExternalId       string
 	roleSessionName      string
 	webIdentityTokenFile string
 	keyNotRequired       bool
@@ -125,6 +126,7 @@ func (k *Wrapper) SetConfig(ctx context.Context, opt ...wrapping.Option) (*wrapp
 	k.webIdentityTokenFile = opts.withWebIdentityTokenFile
 	k.roleSessionName = opts.withRoleSessionName
 	k.roleArn = opts.withRoleArn
+	k.roleExternalId = opts.withRoleExternalId
 
 	if !opts.withDisallowEnvVars {
 		ep := os.Getenv(EnvAwsKmsEndpoint)
@@ -296,7 +298,7 @@ func (k *Wrapper) Decrypt(ctx context.Context, in *wrapping.BlobInfo, opt ...wra
 	switch in.KeyInfo.Mechanism {
 	case AwsKmsEncrypt:
 		input := &kms.DecryptInput{
-			KeyId:     &k.keyId,
+			KeyId:          &k.keyId,
 			CiphertextBlob: in.Ciphertext,
 		}
 		if opts.WithRsaEncryptionPadding != wrapping.RSAEncryptionPadding_Unknown_RSAEncryptionPadding {
@@ -375,6 +377,7 @@ func (k *Wrapper) GetAwsKmsClientInRegion(ctx context.Context, region string) (*
 		Filename:             k.sharedCredsFilename,
 		Profile:              k.sharedCredsProfile,
 		RoleARN:              k.roleArn,
+		RoleExternalId:       k.roleExternalId,
 		RoleSessionName:      k.roleSessionName,
 		WebIdentityTokenFile: k.webIdentityTokenFile,
 		Region:               region,

--- a/wrappers/awskms/awskms_test.go
+++ b/wrappers/awskms/awskms_test.go
@@ -189,6 +189,31 @@ func TestSetConfig(t *testing.T) {
 		trimmedActualKeyId, _ := strings.CutPrefix(keyArn.Resource, "key/")
 		assert.Equal(t, expectedKeyId, trimmedActualKeyId)
 	})
+
+	t.Run("Success - role external ID", func(t *testing.T) {
+		// Setup environment values to ignore for the following values
+		wrapperWithMock := NewWrapper()
+		wrapperWithMock.client = &mockClient{
+			keyId: awsTestKeyId,
+		}
+
+		config := map[string]string{
+			"kms_key_id":       "a-key-key",
+			"access_key":       "a-access-key",
+			"secret_key":       "a-secret-key",
+			"role_arn":         "arn:aws:iam::1234567890:role/test-role",
+			"role_external_id": "a-role-external-id",
+		}
+
+		_, err := wrapperWithMock.SetConfig(context.Background(), wrapping.WithConfigMap(config))
+		require.NoError(t, err)
+
+		require.Equal(t, config["access_key"], wrapperWithMock.accessKey)
+		require.Equal(t, config["secret_key"], wrapperWithMock.secretKey)
+		require.Equal(t, config["kms_key_id"], wrapperWithMock.keyId)
+		require.Equal(t, config["role_arn"], wrapperWithMock.roleArn)
+		require.Equal(t, config["role_external_id"], wrapperWithMock.roleExternalId)
+	})
 }
 
 func TestEncryptAndDecrypt(t *testing.T) {

--- a/wrappers/awskms/options.go
+++ b/wrappers/awskms/options.go
@@ -81,6 +81,8 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 				opts.withRoleSessionName = v
 			case "role_arn":
 				opts.withRoleArn = v
+			case "role_external_id":
+				opts.withRoleExternalId = v
 			}
 		}
 	}
@@ -121,6 +123,7 @@ type options struct {
 	withWebIdentityTokenFile string
 	withRoleSessionName      string
 	withRoleArn              string
+	withRoleExternalId       string
 
 	withLogger hclog.Logger
 }
@@ -239,11 +242,21 @@ func WithRoleSessionName(with string) wrapping.Option {
 	}
 }
 
-// WithRoleArn provides a way to chose the role ARN
+// WithRoleArn provides a way to choose the role ARN
 func WithRoleArn(with string) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {
 			o.withRoleArn = with
+			return nil
+		})
+	}
+}
+
+// WithRoleArn provides a way to choose the role external ID
+func WithRoleExternalId(with string) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.withRoleExternalId = with
 			return nil
 		})
 	}


### PR DESCRIPTION
Make it possible to specify role_external_id for AWS wrappers.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.