### PR TITLE
TencentCloud KMS wrapper: CAM role support, endpoint override, and env var fix

### DIFF
--- a/wrappers/tencentcloudkms/go.mod
+++ b/wrappers/tencentcloudkms/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.24
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.604
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.604
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.0.604
 )
 
 require (

--- a/wrappers/tencentcloudkms/go.sum
+++ b/wrappers/tencentcloudkms/go.sum
@@ -24,6 +24,8 @@ github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.604 h1:BiuY
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.604/go.mod h1:7sCQWVkxcsR38nffDW057DRGk8mUjK1Ing/EFOK8s8Y=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.604 h1:LItsuG1cD+8e/9Z5MBNci2WJpYeNI0j00FN8UU5A3xw=
 github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms v1.0.604/go.mod h1:0NPGaAgj1qcvy3w0wEVhe3hMmDB0ptM+CqzXDu9r658=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.0.604 h1:4AulxOLAOI/SuBxBwPPiwPE9OeGM2e1UMZNsbfhizqQ=
+github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts v1.0.604/go.mod h1:w+DBpcgJn2iFZURqvsmkDHbd1w5/q0YwSPDSt2+9MRY=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=

--- a/wrappers/tencentcloudkms/options.go
+++ b/wrappers/tencentcloudkms/options.go
@@ -4,8 +4,35 @@
 package tencentcloudkms
 
 import (
+	"fmt"
+	"strconv"
+
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 )
+
+const (
+	// minRoleDurationSeconds is the shortest session duration TencentCloud STS
+	// accepts when assuming a role.
+	minRoleDurationSeconds = uint64(900) // 15 minutes
+	// maxRoleDurationSeconds is the longest session duration TencentCloud STS
+	// accepts when assuming a role. Roles with a shorter "max session duration"
+	// configured in CAM will yield an error from the service.
+	maxRoleDurationSeconds = uint64(43200) // 12 hours
+)
+
+// parseRoleDurationSeconds converts a textual duration (in seconds) into a
+// uint64, validating it against the range accepted by TencentCloud STS.
+func parseRoleDurationSeconds(v string) (uint64, error) {
+	d, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid 'role_duration_seconds' value %q: %w", v, err)
+	}
+	if d != 0 && (d < minRoleDurationSeconds || d > maxRoleDurationSeconds) {
+		return 0, fmt.Errorf("invalid 'role_duration_seconds' value %d: must be between %d and %d seconds",
+			d, minRoleDurationSeconds, maxRoleDurationSeconds)
+	}
+	return d, nil
+}
 
 // getOpts iterates the inbound Options and returns a struct
 func getOpts(opt ...wrapping.Option) (*options, error) {
@@ -54,6 +81,18 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 				opts.withSecretKey = v
 			case "session_token":
 				opts.withSessionToken = v
+			case "role_arn":
+				opts.withRoleArn = v
+			case "role_session_name":
+				opts.withRoleSessionName = v
+			case "role_external_id":
+				opts.withRoleExternalId = v
+			case "role_duration_seconds":
+				d, err := parseRoleDurationSeconds(v)
+				if err != nil {
+					return nil, err
+				}
+				opts.withRoleDurationSeconds = d
 			}
 		}
 	}
@@ -82,10 +121,14 @@ type OptionFunc func(*options) error
 type options struct {
 	*wrapping.Options
 
-	withRegion       string
-	withAccessKey    string
-	withSecretKey    string
-	withSessionToken string
+	withRegion          string
+	withAccessKey       string
+	withSecretKey       string
+	withSessionToken    string
+	withRoleArn              string
+	withRoleSessionName      string
+	withRoleExternalId       string
+	withRoleDurationSeconds  uint64
 }
 
 func getDefaultOptions() options {
@@ -129,6 +172,59 @@ func WithSessionToken(with string) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {
 			o.withSessionToken = with
+			return nil
+		})
+	}
+}
+
+// WithRoleArn provides a way to specify a CAM role to assume. When set, the
+// wrapper calls STS AssumeRole with the base credentials (access_key/secret_key)
+// and uses the returned temporary credentials to talk to KMS.
+func WithRoleArn(with string) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.withRoleArn = with
+			return nil
+		})
+	}
+}
+
+// WithRoleSessionName provides a way to choose the session name used when
+// assuming a role.
+func WithRoleSessionName(with string) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.withRoleSessionName = with
+			return nil
+		})
+	}
+}
+
+// WithRoleExternalId provides a way to specify an external id (similar to the
+// AWS external id / confused deputy protection) when assuming a role.
+func WithRoleExternalId(with string) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.withRoleExternalId = with
+			return nil
+		})
+	}
+}
+
+// WithRoleDurationSeconds provides a way to choose how long the temporary
+// credentials obtained from STS AssumeRole remain valid, in seconds. Valid
+// values are between 900 (15 minutes) and 43200 (12 hours); the effective
+// upper bound is also limited by the role's configured max session duration.
+// A value of 0 means "unset", in which case the TencentCloud default (7200
+// seconds) is used.
+func WithRoleDurationSeconds(with uint64) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			if with != 0 && (with < minRoleDurationSeconds || with > maxRoleDurationSeconds) {
+				return fmt.Errorf("invalid role duration seconds %d: must be between %d and %d",
+					with, minRoleDurationSeconds, maxRoleDurationSeconds)
+			}
+			o.withRoleDurationSeconds = with
 			return nil
 		})
 	}

--- a/wrappers/tencentcloudkms/options.go
+++ b/wrappers/tencentcloudkms/options.go
@@ -81,6 +81,8 @@ func getOpts(opt ...wrapping.Option) (*options, error) {
 				opts.withSecretKey = v
 			case "session_token":
 				opts.withSessionToken = v
+			case "endpoint":
+				opts.withEndpoint = v
 			case "role_arn":
 				opts.withRoleArn = v
 			case "role_session_name":
@@ -125,6 +127,7 @@ type options struct {
 	withAccessKey           string
 	withSecretKey           string
 	withSessionToken        string
+	withEndpoint            string
 	withRoleArn             string
 	withRoleSessionName     string
 	withRoleExternalId      string
@@ -172,6 +175,20 @@ func WithSessionToken(with string) wrapping.Option {
 	return func() interface{} {
 		return OptionFunc(func(o *options) error {
 			o.withSessionToken = with
+			return nil
+		})
+	}
+}
+
+// WithEndpoint provides a way to override the KMS service endpoint, for
+// example to reach KMS over a VPC endpoint or in a dedicated cloud
+// environment. The value is a host (optionally host:port) such as
+// "kms.internal.tencentcloudapi.com"; it applies to the KMS client only and
+// does not affect STS calls made when assuming a role.
+func WithEndpoint(with string) wrapping.Option {
+	return func() interface{} {
+		return OptionFunc(func(o *options) error {
+			o.withEndpoint = with
 			return nil
 		})
 	}

--- a/wrappers/tencentcloudkms/options.go
+++ b/wrappers/tencentcloudkms/options.go
@@ -121,14 +121,14 @@ type OptionFunc func(*options) error
 type options struct {
 	*wrapping.Options
 
-	withRegion          string
-	withAccessKey       string
-	withSecretKey       string
-	withSessionToken    string
-	withRoleArn              string
-	withRoleSessionName      string
-	withRoleExternalId       string
-	withRoleDurationSeconds  uint64
+	withRegion              string
+	withAccessKey           string
+	withSecretKey           string
+	withSessionToken        string
+	withRoleArn             string
+	withRoleSessionName     string
+	withRoleExternalId      string
+	withRoleDurationSeconds uint64
 }
 
 func getDefaultOptions() options {

--- a/wrappers/tencentcloudkms/options.go
+++ b/wrappers/tencentcloudkms/options.go
@@ -183,7 +183,7 @@ func WithSessionToken(with string) wrapping.Option {
 // WithEndpoint provides a way to override the KMS service endpoint, for
 // example to reach KMS over a VPC endpoint or in a dedicated cloud
 // environment. The value is a host (optionally host:port) such as
-// "kms.internal.tencentcloudapi.com"; it applies to the KMS client only and
+// "kms.tencentcloudapi.com"; it applies to the KMS client only and
 // does not affect STS calls made when assuming a role.
 func WithEndpoint(with string) wrapping.Option {
 	return func() interface{} {

--- a/wrappers/tencentcloudkms/tencentcloudkms.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms.go
@@ -210,19 +210,10 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	return wrapConfig, nil
 }
 
-// assumeRole exchanges the configured base credentials for temporary
-// credentials by calling STS AssumeRole for k.roleArn. The returned credential
-// is what should be used to construct the KMS client.
-//
-// The base credentials (access_key/secret_key, or whatever was resolved from
-// the environment) only need permission to call sts:AssumeRole on the target
-// role; the KMS permissions live on the assumed role itself.
-func (k *Wrapper) assumeRole(baseCred common.CredentialIface, cpf *profile.ClientProfile) (*common.Credential, error) {
-	stsClient, err := sts.NewClient(baseCred, k.region, cpf)
-	if err != nil {
-		return nil, fmt.Errorf("error initializing TencentCloud STS client: %w", err)
-	}
-
+// buildAssumeRoleRequest assembles the STS AssumeRole request from the
+// wrapper's configuration. It is kept separate from assumeRole so that the
+// parameter assembly can be unit tested without any network access.
+func (k *Wrapper) buildAssumeRoleRequest() *sts.AssumeRoleRequest {
 	sessionName := k.roleSessionName
 	if sessionName == "" {
 		sessionName = defaultRoleSessionName
@@ -237,8 +228,23 @@ func (k *Wrapper) assumeRole(baseCred common.CredentialIface, cpf *profile.Clien
 	if k.roleDurationSeconds != 0 {
 		req.DurationSeconds = common.Uint64Ptr(k.roleDurationSeconds)
 	}
+	return req
+}
 
-	resp, err := stsClient.AssumeRole(req)
+// assumeRole exchanges the configured base credentials for temporary
+// credentials by calling STS AssumeRole for k.roleArn. The returned credential
+// is what should be used to construct the KMS client.
+//
+// The base credentials (access_key/secret_key, or whatever was resolved from
+// the environment) only need permission to call sts:AssumeRole on the target
+// role; the KMS permissions live on the assumed role itself.
+func (k *Wrapper) assumeRole(baseCred common.CredentialIface, cpf *profile.ClientProfile) (*common.Credential, error) {
+	stsClient, err := sts.NewClient(baseCred, k.region, cpf)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing TencentCloud STS client: %w", err)
+	}
+
+	resp, err := stsClient.AssumeRole(k.buildAssumeRoleRequest())
 	if err != nil {
 		return nil, fmt.Errorf("error assuming TencentCloud role %q: %w", k.roleArn, err)
 	}

--- a/wrappers/tencentcloudkms/tencentcloudkms.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms.go
@@ -25,6 +25,7 @@ const (
 	PROVIDER_SECURITY_TOKEN  = "TENCENTCLOUD_SECURITY_TOKEN"
 	PROVIDER_REGION          = "TENCENTCLOUD_REGION"
 	PROVIDER_KMS_KEY_ID      = "TENCENTCLOUD_KMS_KEY_ID"
+	PROVIDER_KMS_ENDPOINT    = "TENCENTCLOUD_KMS_ENDPOINT"
 	PROVIDER_ROLE_ARN        = "TENCENTCLOUD_ROLE_ARN"
 	PROVIDER_ROLE_SESSION_NM = "TENCENTCLOUD_ROLE_SESSION_NAME"
 	PROVIDER_ROLE_EXTERN_ID  = "TENCENTCLOUD_ROLE_EXTERNAL_ID"
@@ -49,6 +50,10 @@ type Wrapper struct {
 	secretKey    string
 	sessionToken string
 	region       string
+
+	// Optional override for the KMS service endpoint, e.g. to reach KMS through
+	// a VPC endpoint. It applies to the KMS client only, never to STS.
+	endpoint string
 
 	// Optional CAM role to assume. When roleArn is set, the accessKey/secretKey
 	// above are treated as the base credentials used to call STS AssumeRole, and
@@ -135,6 +140,13 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	}
 
 	switch {
+	case os.Getenv(PROVIDER_KMS_ENDPOINT) != "" && !opts.Options.WithDisallowEnvVars:
+		k.endpoint = os.Getenv(PROVIDER_KMS_ENDPOINT)
+	case opts.withEndpoint != "":
+		k.endpoint = opts.withEndpoint
+	}
+
+	switch {
 	case os.Getenv(PROVIDER_ROLE_ARN) != "" && !opts.Options.WithDisallowEnvVars:
 		k.roleArn = os.Getenv(PROVIDER_ROLE_ARN)
 	case opts.withRoleArn != "":
@@ -165,24 +177,22 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	}
 
 	if k.client == nil {
-		cpf := profile.NewClientProfile()
-		cpf.HttpProfile.ReqMethod = "POST"
-		cpf.HttpProfile.ReqTimeout = 300
-		cpf.Language = "en-US"
-
 		credential := common.NewTokenCredential(k.accessKey, k.secretKey, k.sessionToken)
 
 		// If a CAM role is configured, exchange the base credentials for
-		// temporary credentials via STS AssumeRole and use those for KMS.
+		// temporary credentials via STS AssumeRole and use those for KMS. Note
+		// that STS gets its own client profile: any endpoint override applies
+		// to KMS only, and reusing the KMS profile here would send the STS
+		// request to the KMS endpoint.
 		if k.roleArn != "" {
-			assumed, err := k.assumeRole(credential, cpf)
+			assumed, err := k.assumeRole(credential, newClientProfile(""))
 			if err != nil {
 				return nil, err
 			}
 			credential = assumed
 		}
 
-		client, err := kms.NewClient(credential, k.region, cpf)
+		client, err := kms.NewClient(credential, k.region, newClientProfile(k.endpoint))
 		if err != nil {
 			return nil, fmt.Errorf("error initializing TencentCloud KMS client: %w", err)
 		}
@@ -206,8 +216,25 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	wrapConfig.Metadata = make(map[string]string)
 	wrapConfig.Metadata["region"] = k.region
 	wrapConfig.Metadata["kms_key_id"] = k.keyId
+	if k.endpoint != "" {
+		wrapConfig.Metadata["endpoint"] = k.endpoint
+	}
 
 	return wrapConfig, nil
+}
+
+// newClientProfile builds the client profile shared by the KMS and STS
+// clients. If endpoint is non-empty the resulting profile targets that
+// endpoint instead of the default service domain.
+func newClientProfile(endpoint string) *profile.ClientProfile {
+	cpf := profile.NewClientProfile()
+	cpf.HttpProfile.ReqMethod = "POST"
+	cpf.HttpProfile.ReqTimeout = 300
+	cpf.Language = "en-US"
+	if endpoint != "" {
+		cpf.HttpProfile.Endpoint = endpoint
+	}
+	return cpf
 }
 
 // buildAssumeRoleRequest assembles the STS AssumeRole request from the

--- a/wrappers/tencentcloudkms/tencentcloudkms.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms.go
@@ -15,16 +15,25 @@ import (
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
 	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common/profile"
 	kms "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/kms/v20190118"
+	sts "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/sts/v20180813"
 )
 
 // These constants are TencentCloud accepted env vars
 const (
-	PROVIDER_SECRET_ID      = "TENCENTCLOUD_SECRET_ID"
-	PROVIDER_SECRET_KEY     = "TENCENTCLOUD_SECRET_KEY"
-	PROVIDER_SECURITY_TOKEN = "TENCENTCLOUD_SECURITY_TOKEN"
-	PROVIDER_REGION         = "TENCENTCLOUD_REGION"
-	PROVIDER_KMS_KEY_ID     = "TENCENTCLOUD_KMS_KEY_ID"
+	PROVIDER_SECRET_ID       = "TENCENTCLOUD_SECRET_ID"
+	PROVIDER_SECRET_KEY      = "TENCENTCLOUD_SECRET_KEY"
+	PROVIDER_SECURITY_TOKEN  = "TENCENTCLOUD_SECURITY_TOKEN"
+	PROVIDER_REGION          = "TENCENTCLOUD_REGION"
+	PROVIDER_KMS_KEY_ID      = "TENCENTCLOUD_KMS_KEY_ID"
+	PROVIDER_ROLE_ARN        = "TENCENTCLOUD_ROLE_ARN"
+	PROVIDER_ROLE_SESSION_NM = "TENCENTCLOUD_ROLE_SESSION_NAME"
+	PROVIDER_ROLE_EXTERN_ID  = "TENCENTCLOUD_ROLE_EXTERNAL_ID"
+	PROVIDER_ROLE_DURATION   = "TENCENTCLOUD_ROLE_DURATION_SECONDS"
 )
+
+// defaultRoleSessionName is used when a role is assumed but no session name
+// was supplied by the caller.
+const defaultRoleSessionName = "go-kms-wrapping-session"
 
 const (
 	// TencentCloudKmsEnvelopeAesGcmEncrypt is when a data encryption key is generated and
@@ -40,6 +49,14 @@ type Wrapper struct {
 	secretKey    string
 	sessionToken string
 	region       string
+
+	// Optional CAM role to assume. When roleArn is set, the accessKey/secretKey
+	// above are treated as the base credentials used to call STS AssumeRole, and
+	// the temporary credentials returned are what actually talk to KMS.
+	roleArn              string
+	roleSessionName      string
+	roleExternalId       string
+	roleDurationSeconds  uint64
 
 	keyId        string
 	currentKeyId *atomic.Value
@@ -112,6 +129,37 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 		k.sessionToken = opts.withSessionToken
 	}
 
+	switch {
+	case os.Getenv(PROVIDER_ROLE_ARN) != "":
+		k.roleArn = os.Getenv(PROVIDER_ROLE_ARN)
+	case opts.withRoleArn != "":
+		k.roleArn = opts.withRoleArn
+	}
+
+	switch {
+	case os.Getenv(PROVIDER_ROLE_SESSION_NM) != "":
+		k.roleSessionName = os.Getenv(PROVIDER_ROLE_SESSION_NM)
+	case opts.withRoleSessionName != "":
+		k.roleSessionName = opts.withRoleSessionName
+	}
+
+	switch {
+	case os.Getenv(PROVIDER_ROLE_EXTERN_ID) != "":
+		k.roleExternalId = os.Getenv(PROVIDER_ROLE_EXTERN_ID)
+	case opts.withRoleExternalId != "":
+		k.roleExternalId = opts.withRoleExternalId
+	}
+
+	if durStr := os.Getenv(PROVIDER_ROLE_DURATION); durStr != "" {
+		d, err := parseRoleDurationSeconds(durStr)
+		if err != nil {
+			return nil, err
+		}
+		k.roleDurationSeconds = d
+	} else {
+		k.roleDurationSeconds = opts.withRoleDurationSeconds
+	}
+
 	if k.client == nil {
 		cpf := profile.NewClientProfile()
 		cpf.HttpProfile.ReqMethod = "POST"
@@ -119,6 +167,17 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 		cpf.Language = "en-US"
 
 		credential := common.NewTokenCredential(k.accessKey, k.secretKey, k.sessionToken)
+
+		// If a CAM role is configured, exchange the base credentials for
+		// temporary credentials via STS AssumeRole and use those for KMS.
+		if k.roleArn != "" {
+			assumed, err := k.assumeRole(credential, cpf)
+			if err != nil {
+				return nil, err
+			}
+			credential = assumed
+		}
+
 		client, err := kms.NewClient(credential, k.region, cpf)
 		if err != nil {
 			return nil, fmt.Errorf("error initializing TencentCloud KMS client: %w", err)
@@ -145,6 +204,56 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	wrapConfig.Metadata["kms_key_id"] = k.keyId
 
 	return wrapConfig, nil
+}
+
+// assumeRole exchanges the configured base credentials for temporary
+// credentials by calling STS AssumeRole for k.roleArn. The returned credential
+// is what should be used to construct the KMS client.
+//
+// The base credentials (access_key/secret_key, or whatever was resolved from
+// the environment) only need permission to call sts:AssumeRole on the target
+// role; the KMS permissions live on the assumed role itself.
+func (k *Wrapper) assumeRole(baseCred common.CredentialIface, cpf *profile.ClientProfile) (*common.Credential, error) {
+	stsClient, err := sts.NewClient(baseCred, k.region, cpf)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing TencentCloud STS client: %w", err)
+	}
+
+	sessionName := k.roleSessionName
+	if sessionName == "" {
+		sessionName = defaultRoleSessionName
+	}
+
+	req := sts.NewAssumeRoleRequest()
+	req.RoleArn = common.StringPtr(k.roleArn)
+	req.RoleSessionName = common.StringPtr(sessionName)
+	if k.roleExternalId != "" {
+		req.ExternalId = common.StringPtr(k.roleExternalId)
+	}
+	if k.roleDurationSeconds != 0 {
+		req.DurationSeconds = common.Uint64Ptr(k.roleDurationSeconds)
+	}
+
+	resp, err := stsClient.AssumeRole(req)
+	if err != nil {
+		return nil, fmt.Errorf("error assuming TencentCloud role %q: %w", k.roleArn, err)
+	}
+	if resp.Response == nil || resp.Response.Credentials == nil {
+		return nil, errors.New("no credentials returned from TencentCloud STS AssumeRole")
+	}
+
+	creds := resp.Response.Credentials
+	if creds.TmpSecretId == nil || creds.TmpSecretKey == nil || creds.Token == nil {
+		return nil, errors.New("incomplete credentials returned from TencentCloud STS AssumeRole")
+	}
+
+	// Stash the temporary credentials on the wrapper so any later client
+	// re-creation is consistent with what was used here.
+	k.accessKey = *creds.TmpSecretId
+	k.secretKey = *creds.TmpSecretKey
+	k.sessionToken = *creds.Token
+
+	return common.NewTokenCredential(k.accessKey, k.secretKey, k.sessionToken), nil
 }
 
 // Type returns the type for this particular wrapper implementation

--- a/wrappers/tencentcloudkms/tencentcloudkms.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms.go
@@ -53,10 +53,10 @@ type Wrapper struct {
 	// Optional CAM role to assume. When roleArn is set, the accessKey/secretKey
 	// above are treated as the base credentials used to call STS AssumeRole, and
 	// the temporary credentials returned are what actually talk to KMS.
-	roleArn              string
-	roleSessionName      string
-	roleExternalId       string
-	roleDurationSeconds  uint64
+	roleArn             string
+	roleSessionName     string
+	roleExternalId      string
+	roleDurationSeconds uint64
 
 	keyId        string
 	currentKeyId *atomic.Value
@@ -88,8 +88,13 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 		return nil, err
 	}
 
+	// Note: when WithDisallowEnvVars is set (which is what Vault does, since it
+	// resolves env vars into the config map itself) we deliberately ignore the
+	// environment here. This matches the behaviour of the other cloud wrappers
+	// (see alicloudkms and awskms) and prevents env vars from silently
+	// overriding an explicitly supplied configuration.
 	switch {
-	case os.Getenv(PROVIDER_KMS_KEY_ID) != "":
+	case os.Getenv(PROVIDER_KMS_KEY_ID) != "" && !opts.Options.WithDisallowEnvVars:
 		k.keyId = os.Getenv(PROVIDER_KMS_KEY_ID)
 	case opts.WithKeyId != "":
 		k.keyId = opts.WithKeyId
@@ -98,14 +103,14 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_REGION) != "":
+	case os.Getenv(PROVIDER_REGION) != "" && !opts.Options.WithDisallowEnvVars:
 		k.region = os.Getenv(PROVIDER_REGION)
 	case opts.withRegion != "":
 		k.region = opts.withRegion
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_SECRET_ID) != "":
+	case os.Getenv(PROVIDER_SECRET_ID) != "" && !opts.Options.WithDisallowEnvVars:
 		k.accessKey = os.Getenv(PROVIDER_SECRET_ID)
 	case opts.withAccessKey != "":
 		k.accessKey = opts.withAccessKey
@@ -114,7 +119,7 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_SECRET_KEY) != "":
+	case os.Getenv(PROVIDER_SECRET_KEY) != "" && !opts.Options.WithDisallowEnvVars:
 		k.secretKey = os.Getenv(PROVIDER_SECRET_KEY)
 	case opts.withSecretKey != "":
 		k.secretKey = opts.withSecretKey
@@ -123,41 +128,40 @@ func (k *Wrapper) SetConfig(_ context.Context, opt ...wrapping.Option) (*wrappin
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_SECURITY_TOKEN) != "":
+	case os.Getenv(PROVIDER_SECURITY_TOKEN) != "" && !opts.Options.WithDisallowEnvVars:
 		k.sessionToken = os.Getenv(PROVIDER_SECURITY_TOKEN)
 	case opts.withSessionToken != "":
 		k.sessionToken = opts.withSessionToken
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_ROLE_ARN) != "":
+	case os.Getenv(PROVIDER_ROLE_ARN) != "" && !opts.Options.WithDisallowEnvVars:
 		k.roleArn = os.Getenv(PROVIDER_ROLE_ARN)
 	case opts.withRoleArn != "":
 		k.roleArn = opts.withRoleArn
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_ROLE_SESSION_NM) != "":
+	case os.Getenv(PROVIDER_ROLE_SESSION_NM) != "" && !opts.Options.WithDisallowEnvVars:
 		k.roleSessionName = os.Getenv(PROVIDER_ROLE_SESSION_NM)
 	case opts.withRoleSessionName != "":
 		k.roleSessionName = opts.withRoleSessionName
 	}
 
 	switch {
-	case os.Getenv(PROVIDER_ROLE_EXTERN_ID) != "":
+	case os.Getenv(PROVIDER_ROLE_EXTERN_ID) != "" && !opts.Options.WithDisallowEnvVars:
 		k.roleExternalId = os.Getenv(PROVIDER_ROLE_EXTERN_ID)
 	case opts.withRoleExternalId != "":
 		k.roleExternalId = opts.withRoleExternalId
 	}
 
-	if durStr := os.Getenv(PROVIDER_ROLE_DURATION); durStr != "" {
+	k.roleDurationSeconds = opts.withRoleDurationSeconds
+	if durStr := os.Getenv(PROVIDER_ROLE_DURATION); durStr != "" && !opts.Options.WithDisallowEnvVars {
 		d, err := parseRoleDurationSeconds(durStr)
 		if err != nil {
 			return nil, err
 		}
 		k.roleDurationSeconds = d
-	} else {
-		k.roleDurationSeconds = opts.withRoleDurationSeconds
 	}
 
 	if k.client == nil {

--- a/wrappers/tencentcloudkms/tencentcloudkms_role_test.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms_role_test.go
@@ -319,7 +319,7 @@ func TestBuildAssumeRoleRequest(t *testing.T) {
 // TestEndpointConfig verifies the endpoint override can be supplied through the
 // config map, the option function, and the environment.
 func TestEndpointConfig(t *testing.T) {
-	const wantEndpoint = "kms.internal.tencentcloudapi.com"
+	const wantEndpoint = "kms.tencentcloudapi.com"
 
 	t.Run("from config map", func(t *testing.T) {
 		w := newTestWrapper()
@@ -400,7 +400,7 @@ func TestNewClientProfile(t *testing.T) {
 	})
 
 	t.Run("with endpoint", func(t *testing.T) {
-		const ep = "kms.internal.tencentcloudapi.com"
+		const ep = "kms.tencentcloudapi.com"
 		cpf := newClientProfile(ep)
 		if cpf.HttpProfile.Endpoint != ep {
 			t.Errorf("Endpoint = %q, want %q", cpf.HttpProfile.Endpoint, ep)
@@ -408,7 +408,7 @@ func TestNewClientProfile(t *testing.T) {
 	})
 
 	t.Run("profiles are independent", func(t *testing.T) {
-		kmsProfile := newClientProfile("kms.internal.tencentcloudapi.com")
+		kmsProfile := newClientProfile("kms.tencentcloudapi.com")
 		stsProfile := newClientProfile("")
 		if stsProfile.HttpProfile.Endpoint != "" {
 			t.Errorf("STS profile picked up the KMS endpoint: %q", stsProfile.HttpProfile.Endpoint)

--- a/wrappers/tencentcloudkms/tencentcloudkms_role_test.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms_role_test.go
@@ -1,0 +1,336 @@
+// Copyright IBM Corp. 2019, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package tencentcloudkms
+
+import (
+	"context"
+	"testing"
+
+	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common"
+)
+
+// newTestWrapper returns a wrapper with a mocked KMS client so that SetConfig
+// does not attempt any network access.
+func newTestWrapper() *Wrapper {
+	w := NewWrapper()
+	w.client = &mockTencentCloudKmsWrapperClient{
+		keyID: common.StringPtr(tencentCloudTestKeyID),
+	}
+	return w
+}
+
+// baseOpts are the options required for SetConfig to succeed, on top of which
+// each test layers the role settings it cares about.
+func baseOpts(extra ...wrapping.Option) []wrapping.Option {
+	opts := []wrapping.Option{
+		wrapping.WithKeyId(tencentCloudTestKeyID),
+		wrapping.WithDisallowEnvVars(true),
+		WithAccessKey("test-access-key"),
+		WithSecretKey("test-secret-key"),
+	}
+	return append(opts, extra...)
+}
+
+// TestParseRoleDurationSeconds covers the client side validation of the
+// role_duration_seconds value.
+func TestParseRoleDurationSeconds(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    uint64
+		wantErr bool
+	}{
+		{"min accepted", "900", 900, false},
+		{"max accepted", "43200", 43200, false},
+		{"mid range", "7200", 7200, false},
+		{"zero means unset", "0", 0, false},
+		{"below minimum", "899", 0, true},
+		{"above maximum", "43201", 0, true},
+		{"not a number", "abc", 0, true},
+		{"negative", "-1", 0, true},
+		{"empty", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRoleDurationSeconds(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseRoleDurationSeconds(%q): expected error, got none", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRoleDurationSeconds(%q): unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseRoleDurationSeconds(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRoleConfigFromConfigMap verifies that all role settings can be supplied
+// through WithConfigMap, which is how Vault passes its seal stanza.
+func TestRoleConfigFromConfigMap(t *testing.T) {
+	const (
+		wantArn      = "qcs::cam::uin/100000002:roleName/CrossAccountKMSRole"
+		wantSession  = "vault-seal"
+		wantExternal = "shared-secret"
+	)
+
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(), baseOpts(
+		wrapping.WithConfigMap(map[string]string{
+			"role_arn":              wantArn,
+			"role_session_name":     wantSession,
+			"role_external_id":      wantExternal,
+			"role_duration_seconds": "43200",
+		}),
+	)...); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if w.roleArn != wantArn {
+		t.Errorf("roleArn = %q, want %q", w.roleArn, wantArn)
+	}
+	if w.roleSessionName != wantSession {
+		t.Errorf("roleSessionName = %q, want %q", w.roleSessionName, wantSession)
+	}
+	if w.roleExternalId != wantExternal {
+		t.Errorf("roleExternalId = %q, want %q", w.roleExternalId, wantExternal)
+	}
+	if w.roleDurationSeconds != 43200 {
+		t.Errorf("roleDurationSeconds = %d, want 43200", w.roleDurationSeconds)
+	}
+}
+
+// TestRoleConfigFromOptionFuncs verifies the exported With* helpers.
+func TestRoleConfigFromOptionFuncs(t *testing.T) {
+	const wantArn = "qcs::cam::uin/100000001:roleName/LocalRole"
+
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(), baseOpts(
+		WithRoleArn(wantArn),
+		WithRoleSessionName("from-option"),
+		WithRoleExternalId("ext-id"),
+		WithRoleDurationSeconds(3600),
+	)...); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if w.roleArn != wantArn {
+		t.Errorf("roleArn = %q, want %q", w.roleArn, wantArn)
+	}
+	if w.roleSessionName != "from-option" {
+		t.Errorf("roleSessionName = %q, want %q", w.roleSessionName, "from-option")
+	}
+	if w.roleExternalId != "ext-id" {
+		t.Errorf("roleExternalId = %q, want %q", w.roleExternalId, "ext-id")
+	}
+	if w.roleDurationSeconds != 3600 {
+		t.Errorf("roleDurationSeconds = %d, want 3600", w.roleDurationSeconds)
+	}
+}
+
+// TestWithRoleDurationSecondsValidation ensures the option function rejects
+// out-of-range values instead of deferring the failure to the STS call.
+func TestWithRoleDurationSecondsValidation(t *testing.T) {
+	for _, d := range []uint64{1, 899, 43201, 100000} {
+		w := newTestWrapper()
+		_, err := w.SetConfig(context.Background(), baseOpts(WithRoleDurationSeconds(d))...)
+		if err == nil {
+			t.Errorf("WithRoleDurationSeconds(%d): expected error, got none", d)
+		}
+	}
+
+	// 0 means "unset" and must be accepted.
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(), baseOpts(WithRoleDurationSeconds(0))...); err != nil {
+		t.Errorf("WithRoleDurationSeconds(0): unexpected error: %v", err)
+	}
+}
+
+// TestInvalidRoleDurationInConfigMap ensures a bad config map value surfaces as
+// a SetConfig error.
+func TestInvalidRoleDurationInConfigMap(t *testing.T) {
+	w := newTestWrapper()
+	_, err := w.SetConfig(context.Background(), baseOpts(
+		wrapping.WithConfigMap(map[string]string{"role_duration_seconds": "not-a-number"}),
+	)...)
+	if err == nil {
+		t.Fatal("expected SetConfig to fail for an invalid role_duration_seconds")
+	}
+}
+
+// TestRoleEnvVars verifies that the role settings are picked up from the
+// environment when env vars are allowed.
+func TestRoleEnvVars(t *testing.T) {
+	t.Setenv(PROVIDER_ROLE_ARN, "qcs::cam::uin/100000003:roleName/FromEnv")
+	t.Setenv(PROVIDER_ROLE_SESSION_NM, "env-session")
+	t.Setenv(PROVIDER_ROLE_EXTERN_ID, "env-external-id")
+	t.Setenv(PROVIDER_ROLE_DURATION, "1800")
+
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(),
+		wrapping.WithKeyId(tencentCloudTestKeyID),
+		WithAccessKey("test-access-key"),
+		WithSecretKey("test-secret-key"),
+	); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if w.roleArn != "qcs::cam::uin/100000003:roleName/FromEnv" {
+		t.Errorf("roleArn = %q, want value from env", w.roleArn)
+	}
+	if w.roleSessionName != "env-session" {
+		t.Errorf("roleSessionName = %q, want %q", w.roleSessionName, "env-session")
+	}
+	if w.roleExternalId != "env-external-id" {
+		t.Errorf("roleExternalId = %q, want %q", w.roleExternalId, "env-external-id")
+	}
+	if w.roleDurationSeconds != 1800 {
+		t.Errorf("roleDurationSeconds = %d, want 1800", w.roleDurationSeconds)
+	}
+}
+
+// TestRoleEnvVarsDisallowed verifies that WithDisallowEnvVars (which is what
+// Vault passes) prevents the environment from being consulted, while values
+// supplied through the config map still take effect.
+func TestRoleEnvVarsDisallowed(t *testing.T) {
+	t.Setenv(PROVIDER_ROLE_ARN, "qcs::cam::uin/100000003:roleName/FromEnv")
+	t.Setenv(PROVIDER_ROLE_DURATION, "1800")
+
+	// Environment must be ignored entirely.
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(), baseOpts()...); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if w.roleArn != "" {
+		t.Errorf("roleArn = %q, want empty (env vars disallowed)", w.roleArn)
+	}
+	if w.roleDurationSeconds != 0 {
+		t.Errorf("roleDurationSeconds = %d, want 0 (env vars disallowed)", w.roleDurationSeconds)
+	}
+
+	// The config map must still win, since that is how Vault forwards the
+	// values it resolved itself.
+	const wantArn = "qcs::cam::uin/100000004:roleName/FromConfig"
+	w2 := newTestWrapper()
+	if _, err := w2.SetConfig(context.Background(), baseOpts(
+		wrapping.WithConfigMap(map[string]string{
+			"role_arn":              wantArn,
+			"role_duration_seconds": "900",
+		}),
+	)...); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+	if w2.roleArn != wantArn {
+		t.Errorf("roleArn = %q, want %q", w2.roleArn, wantArn)
+	}
+	if w2.roleDurationSeconds != 900 {
+		t.Errorf("roleDurationSeconds = %d, want 900", w2.roleDurationSeconds)
+	}
+}
+
+// TestCredentialEnvVarsDisallowed covers the non-role settings, which had the
+// same env var precedence problem.
+func TestCredentialEnvVarsDisallowed(t *testing.T) {
+	t.Setenv(PROVIDER_KMS_KEY_ID, "key-from-env")
+	t.Setenv(PROVIDER_REGION, "ap-shanghai")
+	t.Setenv(PROVIDER_SECRET_ID, "ak-from-env")
+	t.Setenv(PROVIDER_SECRET_KEY, "sk-from-env")
+	t.Setenv(PROVIDER_SECURITY_TOKEN, "token-from-env")
+
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(),
+		wrapping.WithKeyId(tencentCloudTestKeyID),
+		wrapping.WithDisallowEnvVars(true),
+		WithRegion("ap-guangzhou"),
+		WithAccessKey("ak-from-config"),
+		WithSecretKey("sk-from-config"),
+	); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if w.keyId != tencentCloudTestKeyID {
+		t.Errorf("keyId = %q, want %q", w.keyId, tencentCloudTestKeyID)
+	}
+	if w.region != "ap-guangzhou" {
+		t.Errorf("region = %q, want %q", w.region, "ap-guangzhou")
+	}
+	if w.accessKey != "ak-from-config" {
+		t.Errorf("accessKey = %q, want %q", w.accessKey, "ak-from-config")
+	}
+	if w.secretKey != "sk-from-config" {
+		t.Errorf("secretKey = %q, want %q", w.secretKey, "sk-from-config")
+	}
+	if w.sessionToken != "" {
+		t.Errorf("sessionToken = %q, want empty (env vars disallowed)", w.sessionToken)
+	}
+}
+
+// TestBuildAssumeRoleRequest verifies how the wrapper configuration is
+// translated into STS AssumeRole parameters.
+func TestBuildAssumeRoleRequest(t *testing.T) {
+	t.Run("defaults session name and omits optional fields", func(t *testing.T) {
+		w := NewWrapper()
+		w.roleArn = "qcs::cam::uin/1:roleName/R"
+
+		req := w.buildAssumeRoleRequest()
+
+		if req.RoleArn == nil || *req.RoleArn != w.roleArn {
+			t.Errorf("RoleArn = %v, want %q", req.RoleArn, w.roleArn)
+		}
+		if req.RoleSessionName == nil || *req.RoleSessionName != defaultRoleSessionName {
+			t.Errorf("RoleSessionName = %v, want %q", req.RoleSessionName, defaultRoleSessionName)
+		}
+		if req.ExternalId != nil {
+			t.Errorf("ExternalId = %v, want nil when unset", *req.ExternalId)
+		}
+		if req.DurationSeconds != nil {
+			t.Errorf("DurationSeconds = %v, want nil when unset", *req.DurationSeconds)
+		}
+	})
+
+	t.Run("passes through all configured fields", func(t *testing.T) {
+		w := NewWrapper()
+		w.roleArn = "qcs::cam::uin/2:roleName/R2"
+		w.roleSessionName = "my-session"
+		w.roleExternalId = "my-external-id"
+		w.roleDurationSeconds = 43200
+
+		req := w.buildAssumeRoleRequest()
+
+		if req.RoleSessionName == nil || *req.RoleSessionName != "my-session" {
+			t.Errorf("RoleSessionName = %v, want %q", req.RoleSessionName, "my-session")
+		}
+		if req.ExternalId == nil || *req.ExternalId != "my-external-id" {
+			t.Errorf("ExternalId = %v, want %q", req.ExternalId, "my-external-id")
+		}
+		if req.DurationSeconds == nil || *req.DurationSeconds != 43200 {
+			t.Errorf("DurationSeconds = %v, want 43200", req.DurationSeconds)
+		}
+	})
+}
+
+// TestNoRoleConfigured is a regression guard: with no role settings the wrapper
+// must behave exactly as before, i.e. never attempt an AssumeRole.
+func TestNoRoleConfigured(t *testing.T) {
+	w := newTestWrapper()
+	if _, err := w.SetConfig(context.Background(), baseOpts()...); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	if w.roleArn != "" {
+		t.Errorf("roleArn = %q, want empty", w.roleArn)
+	}
+	if w.accessKey != "test-access-key" {
+		t.Errorf("accessKey = %q, want the configured value (not replaced by STS)", w.accessKey)
+	}
+	if w.sessionToken != "" {
+		t.Errorf("sessionToken = %q, want empty (no AssumeRole performed)", w.sessionToken)
+	}
+}

--- a/wrappers/tencentcloudkms/tencentcloudkms_role_test.go
+++ b/wrappers/tencentcloudkms/tencentcloudkms_role_test.go
@@ -316,6 +316,109 @@ func TestBuildAssumeRoleRequest(t *testing.T) {
 	})
 }
 
+// TestEndpointConfig verifies the endpoint override can be supplied through the
+// config map, the option function, and the environment.
+func TestEndpointConfig(t *testing.T) {
+	const wantEndpoint = "kms.internal.tencentcloudapi.com"
+
+	t.Run("from config map", func(t *testing.T) {
+		w := newTestWrapper()
+		info, err := w.SetConfig(context.Background(), baseOpts(
+			wrapping.WithConfigMap(map[string]string{"endpoint": wantEndpoint}),
+		)...)
+		if err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		if w.endpoint != wantEndpoint {
+			t.Errorf("endpoint = %q, want %q", w.endpoint, wantEndpoint)
+		}
+		if got := info.Metadata["endpoint"]; got != wantEndpoint {
+			t.Errorf("metadata endpoint = %q, want %q", got, wantEndpoint)
+		}
+	})
+
+	t.Run("from option func", func(t *testing.T) {
+		w := newTestWrapper()
+		if _, err := w.SetConfig(context.Background(), baseOpts(WithEndpoint(wantEndpoint))...); err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		if w.endpoint != wantEndpoint {
+			t.Errorf("endpoint = %q, want %q", w.endpoint, wantEndpoint)
+		}
+	})
+
+	t.Run("from env var", func(t *testing.T) {
+		t.Setenv(PROVIDER_KMS_ENDPOINT, wantEndpoint)
+		w := newTestWrapper()
+		if _, err := w.SetConfig(context.Background(),
+			wrapping.WithKeyId(tencentCloudTestKeyID),
+			WithAccessKey("ak"), WithSecretKey("sk"),
+		); err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		if w.endpoint != wantEndpoint {
+			t.Errorf("endpoint = %q, want %q", w.endpoint, wantEndpoint)
+		}
+	})
+
+	t.Run("env var ignored when disallowed", func(t *testing.T) {
+		t.Setenv(PROVIDER_KMS_ENDPOINT, wantEndpoint)
+		w := newTestWrapper()
+		if _, err := w.SetConfig(context.Background(), baseOpts()...); err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		if w.endpoint != "" {
+			t.Errorf("endpoint = %q, want empty (env vars disallowed)", w.endpoint)
+		}
+	})
+
+	t.Run("omitted from metadata when unset", func(t *testing.T) {
+		w := newTestWrapper()
+		info, err := w.SetConfig(context.Background(), baseOpts()...)
+		if err != nil {
+			t.Fatalf("SetConfig: %v", err)
+		}
+		if _, ok := info.Metadata["endpoint"]; ok {
+			t.Error("metadata should not contain an endpoint key when unset")
+		}
+	})
+}
+
+// TestNewClientProfile checks that the endpoint override only lands on the
+// profile when one was requested. This matters because the STS client is built
+// with an empty endpoint so that assuming a role is never redirected to the
+// KMS endpoint.
+func TestNewClientProfile(t *testing.T) {
+	t.Run("without endpoint", func(t *testing.T) {
+		cpf := newClientProfile("")
+		if cpf.HttpProfile.Endpoint != "" {
+			t.Errorf("Endpoint = %q, want empty", cpf.HttpProfile.Endpoint)
+		}
+		if cpf.HttpProfile.ReqMethod != "POST" {
+			t.Errorf("ReqMethod = %q, want POST", cpf.HttpProfile.ReqMethod)
+		}
+	})
+
+	t.Run("with endpoint", func(t *testing.T) {
+		const ep = "kms.internal.tencentcloudapi.com"
+		cpf := newClientProfile(ep)
+		if cpf.HttpProfile.Endpoint != ep {
+			t.Errorf("Endpoint = %q, want %q", cpf.HttpProfile.Endpoint, ep)
+		}
+	})
+
+	t.Run("profiles are independent", func(t *testing.T) {
+		kmsProfile := newClientProfile("kms.internal.tencentcloudapi.com")
+		stsProfile := newClientProfile("")
+		if stsProfile.HttpProfile.Endpoint != "" {
+			t.Errorf("STS profile picked up the KMS endpoint: %q", stsProfile.HttpProfile.Endpoint)
+		}
+		if kmsProfile == stsProfile {
+			t.Error("expected distinct profile instances")
+		}
+	})
+}
+
 // TestNoRoleConfigured is a regression guard: with no role settings the wrapper
 // must behave exactly as before, i.e. never attempt an AssumeRole.
 func TestNoRoleConfigured(t *testing.T) {


### PR DESCRIPTION
## Description

Adds two capabilities to the TencentCloud KMS wrapper and fixes one
inconsistency with the other cloud wrappers.

### 1. CAM role support (AssumeRole)

The wrapper could only use static credentials. It can now assume a CAM role
via STS and use the resulting temporary credentials for KMS, so the configured
`access_key`/`secret_key` only need `sts:AssumeRole` rather than direct KMS
permissions. `role_arn` may reference a role in another account, which enables
cross-account KMS access.

New settings (config map / env var / option func):

| Config key | Env var |
|---|---|
| `role_arn` | `TENCENTCLOUD_ROLE_ARN` |
| `role_session_name` | `TENCENTCLOUD_ROLE_SESSION_NAME` |
| `role_external_id` | `TENCENTCLOUD_ROLE_EXTERNAL_ID` |
| `role_duration_seconds` | `TENCENTCLOUD_ROLE_DURATION_SECONDS` |

`role_duration_seconds` is validated client-side against the range STS accepts
(900-43200s). When unset, the service default of 7200s applies.

### 2. Endpoint override

The wrapper always used the default public KMS domain, so it could not be used
where KMS must be reached through a VPC endpoint or in a dedicated cloud
environment. `endpoint` / `TENCENTCLOUD_KMS_ENDPOINT` / `WithEndpoint()` now
allow overriding it. This mirrors `endpoint` in awskms and `domain` in
alicloudkms.

Note that the KMS and STS clients are deliberately given separate client
profiles: the endpoint override must apply to KMS only, since sharing a single
profile would send AssumeRole calls to the KMS endpoint.

### 3. Fix: honor `WithDisallowEnvVars`

Unlike alicloudkms, awskms and the others, this wrapper read `os.Getenv`
unconditionally and ignored `WithDisallowEnvVars`. Since Vault sets that option
and resolves env vars into the config map itself, environment values were
consulted a second time and silently took precedence over explicit
configuration. Every lookup is now guarded, matching the other wrappers.

## Backwards compatibility

- All new settings are optional; when `role_arn` is unset no STS call is made
  and the credential handling is byte-for-byte the same as before.
- Changes are confined to `wrappers/tencentcloudkms/`; no shared code is touched.
- The `WithDisallowEnvVars` fix is a behaviour change for callers that both set
  that option *and* rely on env vars leaking through. That combination is
  contradictory, and the other wrappers already behave this way.

## Testing

The pre-existing tests are all gated behind `VAULT_ACC` and therefore skipped
by default, so this adds `tencentcloudkms_role_test.go` with tests that need
neither credentials nor network access, covering:

- `role_duration_seconds` validation on both the config map and option paths
- role and endpoint settings from config map, option funcs, and env vars
- `WithDisallowEnvVars` being honored for credential, role, and endpoint settings
- AssumeRole request assembly (session name default, omission of unset fields)
- KMS/STS client profile isolation
- a regression guard asserting nothing changes when no role is configured

Package coverage goes from effectively 0% to ~53%.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Reverting the pull request is sufficient; there are no migrations or persisted
  state changes involved.

- [x] If applicable, I've documented the impact of any changes to security controls.

  This change adds an authentication path (STS AssumeRole) that lets operators
  grant KMS access to a role instead of embedding long-lived credentials with
  direct KMS permissions, which reduces the blast radius of a leaked key.
  `role_external_id` is supported for confused-deputy protection on
  cross-account access. The `WithDisallowEnvVars` fix removes a case where
  environment variables could silently override explicit configuration.