### PR TITLE
ocikms: do not panic when OCI retry sees a nil Response

### DIFF
--- a/wrappers/ocikms/ocikms.go
+++ b/wrappers/ocikms/ocikms.go
@@ -369,9 +369,13 @@ func (k *Wrapper) getOciKmsManagementClient() (*keymanagement.KmsManagementClien
 
 // Request metadata includes retry policy
 func (k *Wrapper) getRequestMetadata() common.RequestMetadata {
-	// Only retry for 5xx errors
+	// Only retry for 5xx errors. Response may be nil when auth fails before HTTP.
 	retryOn5xxFunc := func(r common.OCIOperationResponse) bool {
-		return r.Error != nil && r.Response.HTTPResponse().StatusCode >= 500
+		if r.Error == nil || r.Response == nil {
+			return false
+		}
+		httpResp := r.Response.HTTPResponse()
+		return httpResp != nil && httpResp.StatusCode >= 500
 	}
 	return getRequestMetadataWithCustomizedRetryPolicy(retryOn5xxFunc)
 }

--- a/wrappers/ocikms/ocikms_test.go
+++ b/wrappers/ocikms/ocikms_test.go
@@ -2,11 +2,14 @@
 package ocikms
 
 import (
+	"errors"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
 
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
+	"github.com/oracle/oci-go-sdk/v65/common"
 	"golang.org/x/net/context"
 )
 
@@ -77,4 +80,70 @@ func initSeal(t *testing.T) *Wrapper {
 	}
 
 	return s
+}
+
+type stubOCIResponse struct {
+	status  int
+	nilHTTP bool
+}
+
+func (s stubOCIResponse) HTTPResponse() *http.Response {
+	if s.nilHTTP {
+		return nil
+	}
+	return &http.Response{StatusCode: s.status}
+}
+
+func TestGetRequestMetadata_RetryOn5xx(t *testing.T) {
+	errFakeSigner := errors.New("failed to construct authentication signer")
+	policy := NewWrapper().getRequestMetadata().RetryPolicy
+	if policy == nil || policy.ShouldRetryOperation == nil {
+		t.Fatal("expected retry policy with ShouldRetryOperation")
+	}
+
+	cases := []struct {
+		name string
+		resp common.OCIOperationResponse
+		want bool
+	}{
+		{
+			name: "nil response does not panic",
+			resp: common.OCIOperationResponse{Error: errFakeSigner, Response: nil},
+			want: false,
+		},
+		{
+			name: "no error",
+			resp: common.OCIOperationResponse{Response: stubOCIResponse{status: 500}},
+			want: false,
+		},
+		{
+			name: "error with 500",
+			resp: common.OCIOperationResponse{Error: errFakeSigner, Response: stubOCIResponse{status: 500}},
+			want: true,
+		},
+		{
+			name: "error with 400",
+			resp: common.OCIOperationResponse{Error: errFakeSigner, Response: stubOCIResponse{status: 400}},
+			want: false,
+		},
+		{
+			name: "error with nil HTTP response",
+			resp: common.OCIOperationResponse{Error: errFakeSigner, Response: stubOCIResponse{nilHTTP: true}},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if rec := recover(); rec != nil {
+					t.Fatalf("ShouldRetryOperation panicked: %v", rec)
+				}
+			}()
+			got := policy.ShouldRetryOperation(tc.resp)
+			if got != tc.want {
+				t.Fatalf("ShouldRetryOperation() = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The ocikms 5xx retry predicate called `r.Response.HTTPResponse()` whenever `r.Error != nil`. OCI auth failures can produce `{Error: err, Response: nil}` before any HTTP round trip, which panics inside the SDK retry loop.

Skip retry when `Response` or `HTTPResponse()` is nil; only retry on HTTP status >= 500.

Fixes #324

## Test plan

- [x] `cd wrappers/ocikms && go test -count=1`
- [x] Unit coverage for nil Response, nil HTTPResponse, 500, 400, and no-error cases